### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ sudo apt-get install -y nodejs
 npm install -g yarn
 ```
 
-### Clone openebs-docs repository
+### Clone litmus-docs repository
 
 ```bash
-git clone https://github.com/openebs/litmus-docs.git
+git clone https://github.com/litmuschaos/litmus-docs.git
 cd litmus-docs
 ```
 


### PR DESCRIPTION
In readme, the repository name was openebs-docs, but it should be litmus-docs

Signed-off-by: Jayadeep KM <jayadeep.km@sap.com>