### PR TITLE
Remove header Links

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -19,23 +19,11 @@ const siteConfig = {
     indexName: "litmus",
     inputSelector: "### REPLACE ME ####",
     debug: true
-    },
+  },
 
-    headerLinks: [
-       
-	{
-	    href: "https://github.com/litmuschaos/litmus", label: "GitHub"
-	},
-	{
-	    href: "https://kubernetes.slack.com/messages/CNXNB0ZTN", label: "Slack"
-	},
-	{
-	    href: "https://hub.litmuschaos.io", label: "Chaos Hub"
-	},
-        {
-            search: true
-        },
-    //{page: 'help', label: 'Help'},
+  headerLinks: [
+    { search: true },
+    // {page: 'help', label: 'Help'},
   ],
   users,
   onPageNav: 'separate',


### PR DESCRIPTION
Fixes [#818](https://github.com/litmuschaos/litmus/issues/818)
The header contents are getting mixed-up in mobile view. Removing the links in the header is one of the easier options to fix it. Anyway, these links are already there in the footer.