### PR TITLE
Fix instructions in getting started and example pages

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -7,8 +7,7 @@ sidebar_label: Chaos Example
 
 ## Example of running a chaos experiment
 
-In this example we will create an `nginx` deployment and try to inject `pod-delete` chaos.
-
+In this example we will create an `nginx` deployment and try to inject `pod-delete` chaos. We will deploy nginx under `litmus` namespace itself to simplify the process of access control. Please refer to [Get Started page](https://docs.litmuschaos.io/docs/next/getstarted.html) if you want to run the experiment on a deployment under a different namespace.
 
 
 If you have not already installed Litmus, install it by using the following command.
@@ -20,21 +19,20 @@ kubectl apply -f https://litmuschaos.github.io/pages/litmus-operator-latest.yaml
 Similarly, if you have not already installed generic chaos experiments, install the generic chaos chart by using the following command.
 
 ```
-kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/experiments.yaml
+kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/experiments.yaml -n litmus
 ```
-
 
 
 - Start  nginx application
 
 ```console
-kubectl run myserver --image=nginx
+kubectl run myserver --image=nginx -n litmus
 ```
 
 - Annotate your application to permit Litmus chaos operator to run chaos experiments on the application.
 
 ```console
-kubectl annotate deploy/myserver litmuschaos.io/chaos="true"
+kubectl annotate deploy/myserver litmuschaos.io/chaos="true" -n litmus
 ```
 
 - Create the ChaosEngine CR using the application and chaos experiment details.
@@ -50,7 +48,7 @@ metadata:
   namespace: litmus
 spec:
   appinfo: 
-    appns: default # App namespace
+    appns: litmus # App namespace
     # FYI, To see app label, apply kubectl get pods --show-labels
     applabel: "run=myserver" # App Label
   chaosServiceAccount: litmus
@@ -71,7 +69,7 @@ It takes upto a couple of minutes for the experiments to be run and the result C
 - Observe the ChaosResult CR Status to know the status of the experiment. If the experiment is still in progress, the ```spec.verdict``` is set to `running`. If the experiment is completed, the `spec.verdict` is set to either `pass` or `fail`
 
 ```console
-kubectl describe chaosresult engine-nginx-pod-delete
+kubectl describe chaosresult engine-nginx-pod-delete -n litmus
 ```
 
 > Observed Output:
@@ -99,7 +97,7 @@ Events:       <none>
 
 > Note: You may observe the pod status by the following command. And observe that nginx pod getting deleted couple of times and recreated.
 >
-> `watch -n 1 kubectl get pods`
+> `watch -n 1 kubectl get pods -n litmus`
 
 <br>
 

--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -16,7 +16,9 @@ Running chaos on your application involves the following steps:
 
 [Install Litmus](#install-litmus)
 
-[Install  Chaos Experiments](#install-chaos-experiments)
+[Install Chaos Experiments](#install-chaos-experiments)
+
+[Setup ServiceAccount](#setup-serviceaccount)
 
 [Prepare ChaosEngine](#prepare-chaosengine)
 
@@ -92,11 +94,45 @@ Verify if the chaos experiments are installed.
 kubectl get chaosexperiments -n litmus
 ```
 
+### Setup ServiceAccount
 
+If the application is deployed under a different namespace than `litmus`, a ServiceAccount should be created to allow chaosengine to run experiments on your namespace. Copy the following into `rbac.yaml` and run `kubectl apply -f rbac.yaml`. You can change the service account name and namespace as needed.
+
+```yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nginx
+rules:
+- apiGroups: ["", "extensions", "apps", "batch", "litmuschaos.io"]
+  resources: ["daemonsets", "deployments", "replicasets", "jobs", "pods", "pods/exec", "events", "chaosengines", "chaosexperiments", "chaosresults"]
+  verbs: ["*"] 
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nginx
+subjects:
+- kind: ServiceAccount
+  name: nginx
+  namespace: default # App namespace
+roleRef:
+  kind: ClusterRole
+  name: nginx
+  apiGroup: rbac.authorization.k8s.io
+```
 
 ### Prepare ChaosEngine 
 
-ChaosEngine connects the application to the Chaos Experiment. Copy the following YAML snippet into a file called chaosengine.yaml and update `applabel` and `experiments` as per your choice.
+ChaosEngine connects the application to the Chaos Experiment. Copy the following YAML snippet into a file called chaosengine.yaml and update `applabel` and `experiments` as per your choice. Change the `chaosServiceAccount` to the name of ServiceAccount created in above step, if applicable.
 
 ```yaml
 # chaosengine.yaml
@@ -110,7 +146,7 @@ spec:
     appns: default # App namespace
     # FYI, To see app label, apply kubectl get pods --show-labels
     applabel: "run=myserver" # App Label
-  chaosServiceAccount: litmus
+  chaosServiceAccount: nginx # Service account name
   experiments:
     - name: pod-delete
       spec:
@@ -147,6 +183,7 @@ Observe the ChaosResult CR Status to know the status of each experiment. The ```
 kubectl describe chaosresult engine-nginx-pod-delete
 ```
 
+> The above guide is assuming that the application is deployed under default namespace. If you are using a different namespace, make sure to follow all the steps under your namespace by adding `-n my-namespace` to the commands. Also, update the `rbac.yaml` and `chaosengine.yaml` to specify the namespace.
 
 
 ## Uninstallation


### PR DESCRIPTION
Signed-off-by: Jayadeep KM <kmjayadeep@gmail.com>

Closes litmuschaos/litmus#817

- [X] Fix the instructions in Example page - add litmus namespace to the commands to make it work
- [x] In Getting started page, add proper instructions to run tests on an existing deployment under a different namespace