### PR TITLE
Add overview page link in sidebar of version 0.6.0

### DIFF
--- a/website/versioned_sidebars/version-0.6.0-sidebars.json
+++ b/website/versioned_sidebars/version-0.6.0-sidebars.json
@@ -1,6 +1,7 @@
 {
   "version-0.6.0-docs": {
-    "Dcoumentation": [
+    "Documentation": [
+      "version-0.6.0-overview",
       "version-0.6.0-getstarted",
       "version-0.6.0-example",
       "version-0.6.0-chaoshub",

--- a/website/versioned_sidebars/version-0.7.0-sidebars.json
+++ b/website/versioned_sidebars/version-0.7.0-sidebars.json
@@ -1,14 +1,14 @@
 {
-    "version-0.7.0-docs": {
-      "Dcoumentation": [
-        "version-0.7.0-getstarted",
-        "version-0.7.0-example",
-        "version-0.7.0-chaoshub",
-        "version-0.7.0-plugins",
-        "version-0.7.0-architecture",
-        "version-0.7.0-resources",
-        "version-0.7.0-community",
-        "version-0.7.0-devguide"
-      ]
-    }
- }
+  "version-0.7.0-docs": {
+    "Documentation": [
+      "version-0.7.0-getstarted",
+      "version-0.7.0-example",
+      "version-0.7.0-chaoshub",
+      "version-0.7.0-plugins",
+      "version-0.7.0-architecture",
+      "version-0.7.0-resources",
+      "version-0.7.0-community",
+      "version-0.7.0-devguide"
+    ]
+  }
+}


### PR DESCRIPTION
- All the older versions should have an overview file or an link to
overview file in versioned_sidebar otherwise the sidebar will not be
visible in that version.

Signed-off-by: Akash Srivastava <akashsrivastava4927@gmail.com>