### PR TITLE
added versioned docs for example page

### DIFF
--- a/website/versioned_docs/version-0.7.0/example.md
+++ b/website/versioned_docs/version-0.7.0/example.md
@@ -1,0 +1,139 @@
+---
+id: version-0.7.0-example 
+title: Chaos Example
+sidebar_label: Chaos Example
+original_id: example
+---
+------
+<html>
+<head>
+<style>
+div {
+  margin-bottom: 15px;
+  padding: 4px 12px;
+}
+.danger {
+  background-color: #ffdddd;
+  border-left: 6px solid #f44336;
+}
+</style>
+</head>
+<body>
+
+## Example of running a chaos experiment
+In this example we will create an `nginx` deployment and try to inject `pod-delete` chaos. We will deploy nginx under `litmus` namespace itself to simplify the process of access control. Please refer to [Get Started page](getstarted.html) if you want to run the experiment on a deployment under a different namespace.
+
+
+If you have not already installed Litmus, install it by using the following command.
+
+```
+kubectl apply -f https://litmuschaos.github.io/pages/litmus-operator-v0.7.0.yaml
+```
+
+Similarly, if you have not already installed generic chaos experiments, install the generic chaos chart by using the following command.
+
+```
+kubectl create -f https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/experiments.yaml -n litmus
+```
+
+
+- Start  nginx application
+
+```console
+kubectl run myserver --image=nginx -n litmus
+```
+
+- Annotate your application to permit Litmus chaos operator to run chaos experiments on the application.
+
+```console
+kubectl annotate deploy/myserver litmuschaos.io/chaos="true" -n litmus
+```
+
+- Create the ChaosEngine CR using the application and chaos experiment details.
+
+Create a file **"chaosengine.yaml"** and paste the below yaml script.
+
+```yaml
+# chaosengine.yaml
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: engine-nginx
+  namespace: litmus
+spec:
+  appinfo: 
+    appns: litmus # App namespace
+    # FYI, To see app label, apply kubectl get pods --show-labels
+    applabel: "run=myserver" # App Label
+    appkind: deployment # App kind - deployment/statefulset
+  chaosServiceAccount: litmus
+  experiments:
+    - name: pod-delete
+      spec:
+        rank: 1
+```
+
+- Apply the chaosengine.yaml using `kubectl` command.
+
+```console
+kubectl create -f chaosengine.yaml
+```
+
+It takes upto a couple of minutes for the experiments to be run and the result CR to be created. 
+
+- Observe the ChaosResult CR Status to know the status of the experiment. If the experiment is still in progress, the ```spec.verdict``` is set to `running`. If the experiment is completed, the `spec.verdict` is set to either `pass` or `fail`
+
+```console
+kubectl describe chaosresult engine-nginx-pod-delete -n litmus
+```
+
+ Observed Output:
+
+```yaml
+Name:         engine-nginx-pod-delete
+Namespace:    default
+Labels:       <none>
+Annotations:  kubectl.kubernetes.io/last-applied-configuration:
+              {"apiVersion":"litmuschaos.io/v1alpha1","kind":"ChaosResult","metadata":{"annotations":{},"name":"engine-nginx-pod-delete","namespace":"de...
+API Version:  litmuschaos.io/v1alpha1
+Kind:         ChaosResult
+Metadata:
+  Creation Timestamp:  2019-05-22T12:10:19Z
+  Generation:          9
+  Resource Version:    8898730
+  Self Link:           /apis/litmuschaos.io/v1alpha1/namespaces/default/chaosresults/engine-nginx-pod-delete
+  UID:                 911ada69-7c8a-11e9-b37f-42010a80019f
+Spec:
+  Experimentstatus:
+    Phase:    <nil>
+    Verdict:  pass
+Events:       <none>
+```
+<div class="danger">
+<strong> Note:</strong> You may observe the pod status by the following command. And observe that nginx pod getting deleted couple of times and recreated.
+</div>
+
+> `watch -n 1 kubectl get pods -n litmus`
+
+<br>
+
+<br>
+
+<hr>
+
+<br>
+
+<br>
+</body>
+</html>
+<!-- Global site tag (gtag.js) - Google Analytics -->
+
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-92076314-12"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-92076314-12');
+</script>
+


### PR DESCRIPTION
- Copied example.md to versioned docs 0.7 so that we can have different versions, similar to other pages.
- Added `appkind: deployment` in chaosengine.yaml to make it compatible with 0.7
- Litmus operator yaml file link is changed to include version number (similar to getting started page)
- Modified link to getting started page to use relative path instead of absolute url (as specified in https://docusaurus.io/docs/en/navigation

No other changes in md file

fixes litmuschaos/litmus#905

Signed-off-by: Jayadeep KM <kmjayadeep@gmail.com>