### PR TITLE
(refactor): Modify docs fixed typo and grammatical mistakes 

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,11 +9,11 @@ sidebar_label: Architecture
 
 **Chaos-Operator**
 
-Chaos-Operator watches for the ChaosEngine CR and executes the Chaos-Experiments mentioned in the CR. Chaos-Operator is namespace scoped. By default it runs in `litmus` namespace. Once the experiment is completed, chaos-operator invokes chaos-exporter to export chaos metrics to a Prometheus database. 
+Chaos-Operator watches for the ChaosEngine CR and executes the Chaos-Experiments mentioned in the CR. Chaos-Operator is namespace scoped. By default, it runs in `litmus` namespace. Once the experiment is completed, chaos-operator invokes chaos-exporter to export chaos metrics to a Prometheus database. 
 
 **Chaos-CRDs**
 
-During installation, following three CRDs are installed on the Kubernetes cluster. 
+During installation, the following three CRDs are installed on the Kubernetes cluster. 
 
 `chaosengines.litmuschaos.io`
 

--- a/docs/chaoshub.md
+++ b/docs/chaoshub.md
@@ -60,7 +60,7 @@ Application developers write negative tests in their CI pipelines to test the re
 
 
 
-Following Application Chaos, experiments are available on ChaosHub
+Following Application Chaos experiments are available on ChaosHub
 
 
 
@@ -74,7 +74,7 @@ Following Application Chaos, experiments are available on ChaosHub
 
 Chaos experiments that inject chaos into the platform resources of Kubernetes are classified into this category. Management of platform resources vary significantly from each other, Chaos Charts may be maintained separately for each platform (For example, AWS, GCP, Azure, etc)
 
-Following Platform Chaos, experiments are available on ChaosHub
+Following Platform Chaos experiments are available on ChaosHub
 
 
 

--- a/docs/chaoshub.md
+++ b/docs/chaoshub.md
@@ -48,7 +48,7 @@ Chaos actions that apply to generic Kubernetes resources are classified into thi
 
 ### Application Chaos
 
-While Chaos Experiments under Generic category offer the ability to induce chaos into Kubernetes resources, it is difficult to analyse and conclude if the chaos induced found a weakness in a given application. The application specific chaos experiments are built with some checks on *pre-conditions* and some expected outcomes after the chaos injection. The result of the chaos experiment is determined by matching the outcome with expected outcome. 
+While Chaos Experiments under the Generic category offer the ability to induce chaos into Kubernetes resources, it is difficult to analyze and conclude if the chaos induced found a weakness in a given application. The application specific chaos experiments are built with some checks on *pre-conditions* and some expected outcomes after the chaos injection. The result of the chaos experiment is determined by matching the outcome with the expected outcome. 
 
 <div class="danger">
 <strong>Note:</strong> If the result of the chaos experiment is `pass`, it means that the application is resilient to that chaos.
@@ -56,11 +56,11 @@ While Chaos Experiments under Generic category offer the ability to induce chaos
 
 **Benefits of contributing an application chaos experiment**
 
-Application developers write negative tests in their CI pipelines to test the resiliency of the applications. These negative can be converted into Litmus Chaos Experiments and contributed to ChaosHub, so that the users of the application can use them in staging/pre-production/production environments to check the resilience. Application environments vary considerably from where they are tested (CI pipelines) to where they are deployed (Production). Hence, running the same chaos tests in user's environment will help determine the weaknesses of the deployment and fixing such weaknesses leads to increased resilience. 
+Application developers write negative tests in their CI pipelines to test the resiliency of the applications. These negative can be converted into Litmus Chaos Experiments and contributed to ChaosHub, so that the users of the application can use them in staging/pre-production/production environments to check the resilience. Application environments vary considerably from where they are tested (CI pipelines) to where they are deployed (Production). Hence, running the same chaos tests in the user's environment will help determine the weaknesses of the deployment and fixing such weaknesses leads to increased resilience. 
 
 
 
-Following Application Chaos experiments are available on ChaosHub
+Following Application Chaos, experiments are available on ChaosHub
 
 
 
@@ -72,9 +72,9 @@ Following Application Chaos experiments are available on ChaosHub
 
 ### Platform Chaos
 
-Chaos experiments that inject chaos into the platform resources of Kubernetes are classified into this category. Management of platform resources vary significantly from each other, Chaos Charts may be maintained seperately for each platform (For example, AWS, GCP, Azure etc)
+Chaos experiments that inject chaos into the platform resources of Kubernetes are classified into this category. Management of platform resources vary significantly from each other, Chaos Charts may be maintained separately for each platform (For example, AWS, GCP, Azure, etc)
 
-Following Platform Chaos experiments are available on ChaosHub
+Following Platform Chaos, experiments are available on ChaosHub
 
 
 

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -49,8 +49,7 @@ Here is an example of the litmus book for the [pod-delete](https://github.com/li
 
 ### Chaos functions
 
-The `ansible` business logic inside Litmus books can make use of readily available chaos functions. The chaos functions are available 
-as `task-files` which are wrapped in one of the chaos libraries. See [plugins](/docs/next/plugins.html) for more details.
+The `ansible` business logic inside Litmus books can make use of readily available chaos functions. The chaos functions are available as `task-files` which are wrapped in one of the chaos libraries. See [plugins](/docs/next/plugins.html) for more details.
 
 <hr>
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -21,8 +21,7 @@ div {
 
 ## Example of running a chaos experiment
 
-In this example we will create an `nginx` deployment and try to inject `pod-delete` chaos. We will deploy nginx under `litmus` namespace itself to simplify the process of access control. Please refer to [Get Started page](https://docs.litmuschaos.io/docs/next/getstarted.html) if you want to run the experiment on a deployment under a different namespace.
-
+In this example, we will create an `nginx` deployment and try to inject `pod-delete` chaos. We will deploy nginx under `litmus` namespace itself to simplify the process of access control. Please refer to [Get Started page](https://docs.litmuschaos.io/docs/next/getstarted.html) if you want to run the experiment on deployment under a different namespace.
 
 If you have not already installed Litmus, install it by using the following command.
 
@@ -110,7 +109,7 @@ Spec:
 Events:       <none>
 ```
 <div class="danger">
-<strong> Note:</strong> You may observe the pod status by the following command. And observe that nginx pod getting deleted couple of times and recreated.
+<strong> Note:</strong> You may observe the pod status by the following command. And observe that nginx pod getting deleted a couple of times and recreated.
 </div>
 
 > `watch -n 1 kubectl get pods -n litmus`

--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -186,7 +186,7 @@ experiments:
 
 ### Annotate your application
 
-Your application has to be annotated with `litmuschaos.io/chaos="true"`. As a security measure, Chaos Operator checks for this annotation on the application before invoking chaos experiment(s) on the application. Replace `myserver` with a name of your deployment.
+Your application has to be annotated with `litmuschaos.io/chaos="true"`. As a security measure, Chaos Operator checks for this annotation on the application before invoking chaos experiment(s) on the application. Replace `myserver` with an name of your deployment.
 
 ```console
 kubectl annotate deploy/myserver litmuschaos.io/chaos="true"

--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -95,7 +95,7 @@ deployed in the default namespace.
 
 Chaos experiments contain the actual chaos details. These experiments are installed on to your cluster as Kubernetes CRs (or Custom Resources). The Chaos Experiments are grouped as Chaos Charts and are published on <a href=" https://hub.litmuschaos.io" target="_blank">Chaos Hub</a>. 
 
-The generic chaos experiments such as `pod-kill`, `container-kill`,` network-delay` are avaialbe under Generic Chaos Chart. This is the first chart you install. You can later install application specific chaos charts for running application specific chaos.
+The generic chaos experiments such as `pod-kill`, `container-kill`,` network-delay` are available under Generic Chaos Chart. This is the first chart you install. You can later install application specific chaos charts for running application specific chaos.
 
 ```
 kubectl create -f https://hub.litmuschaos.io/api/chaos?file=charts/generic/experiments.yaml
@@ -126,7 +126,7 @@ metadata:
   name: nginx
 rules:
 - apiGroups: ["", "extensions", "apps", "batch", "litmuschaos.io"]
-  resources: ["daemonsets", "deployments", "replicasets", "jobs", "pods", "pods/exec", "events", "chaosengines", "chaosexperiments", "chaosresults"]
+  resources: ["daemonsets", "deployments", "replicasets", "jobs", "pods", "pods/exec","nodes","events", "chaosengines", "chaosexperiments", "chaosresults"]
   verbs: ["*"] 
 ---
 kind: ClusterRoleBinding
@@ -145,7 +145,7 @@ roleRef:
 
 ### Prepare ChaosEngine 
 
-ChaosEngine connects the application to the Chaos Experiment. Copy the following YAML snippet into a file called chaosengine.yaml and update `applabel` and `experiments` as per your choice. Toggle `monitoring` between `true`/`false`, to allow the chaos-exporter to fetch experiment related metrics. Change the `chaosServiceAccount` to the name of ServiceAccount created in above step, if applicable.
+ChaosEngine connects the application to the Chaos Experiment. Copy the following YAML snippet into a file called chaosengine.yaml and update `applabel` and `experiments` as per your choice. Toggle `monitoring` between `true`/`false`, to allow the chaos-exporter to fetch experiment related metrics. Change the `chaosServiceAccount` to the name of ServiceAccount created in the above step, if applicable.
 
 ```yaml
 # chaosengine.yaml
@@ -186,7 +186,7 @@ experiments:
 
 ### Annotate your application
 
-Your application has to be annotated with `litmuschaos.io/chaos="true"`. As a security measure, Chaos Operator checks for this annotation on the application before invoking chaos experiment(s) on the application. Replace `myserver` with an name of your deployment.
+Your application has to be annotated with `litmuschaos.io/chaos="true"`. As a security measure, Chaos Operator checks for this annotation on the application before invoking chaos experiment(s) on the application. Replace `myserver` with a name of your deployment.
 
 ```console
 kubectl annotate deploy/myserver litmuschaos.io/chaos="true"

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -11,7 +11,7 @@ sidebar_label: Resources
 
 ### Getting Started
 
-Use this video to learn how to get started with Litmus. You will learn how to install Litmus, how to inject a fault into your applicaiton using one of the experiments available at ChaosHub. 
+Use this video to learn how to get started with Litmus. You will learn how to install Litmus, how to inject a fault into your application using one of the experiments available at ChaosHub.
 
 <a href="https://asciinema.org/a/G9TcXpgikLuGTBY7btIUNSuWN" target="_blank">
 


### PR DESCRIPTION
Signed-off-by: udit <uditgaurav@gmail.com>

This PR contains the modified docs fixed typo and grammatical mistakes.
Files changed:
- getstarted.md
- chaoshub.md
- plugins.md
- architecture.md
- resources.md
- devguide.md