### PR TITLE
Fixed sample-chaos -> nginx-chaos typo

### DIFF
--- a/docs/pod-delete.md
+++ b/docs/pod-delete.md
@@ -101,7 +101,7 @@ spec:
 
 - Check whether the application is resilient to the pod failure, once the experiment (job) is completed. The ChaosResult resource name is derived like this: `<ChaosEngine-Name>-<ChaosExperiment-Name>`.
 
-  `kubectl describe chaosresult sample-chaos-pod-delete -n <application-namespace>`
+  `kubectl describe chaosresult nginx-chaos-pod-delete -n <application-namespace>`
 
 ## Application Pod Failure Demo
 


### PR DESCRIPTION
I noticed a tiny typo, the engine was called sample-chaos before and then changed to nginx-chaos, but not in the last command.