### PR TITLE
(docs): Removed OpenShift(Baremetal) platform from docs for pod-network-latency

### DIFF
--- a/docs/pod-network-latency.md
+++ b/docs/pod-network-latency.md
@@ -9,7 +9,7 @@ sidebar_label: Pod Network Latency
 
 | Type      | Description              | Tested K8s Platform                                               |
 | ----------| ------------------------ | ------------------------------------------------------------------|
-| Generic   | Inject Network Latency Into Application Pod | GKE, Konvoy(AWS), Packet(Kubeadm), OpenShift(Baremetal) , Minikube > v1.6.0 |
+| Generic   | Inject Network Latency Into Application Pod | GKE, Konvoy(AWS), Packet(Kubeadm) , Minikube > v1.6.0 |
 
 ## Prerequisites
 - Ensure that the Litmus Chaos Operator is running


### PR DESCRIPTION
- Removed OpenShift(Baremetal) platform as a Tested K8s Platform from pod-network-latency


Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>
