### PR TITLE
fix(docs): Update hyperlink to Setup service account

### DIFF
--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -17,11 +17,11 @@ Running chaos on your application involves the following steps:
 
 [Install Chaos Experiments](#install-chaos-experiments)
 
-[Setup Service Account](#setup-serviceaccount)
-
-[Prepare ChaosEngine](#prepare-chaosengine)
+[Setup Service Account](#setup-service-account)
 
 [Annotate your application](#annotate-your-application)
+
+[Prepare ChaosEngine](#prepare-chaosengine)
 
 [Run Chaos](#run-chaos)
 


### PR DESCRIPTION
- Updated hyperlink to "Setup Service Account" listed under Getting started section.
- Moved "annotate application" before "prepare choasengine" under Getting started section to get the correct flow in the beginning itself.

Signed-off-by: Ranjith R <ranjith.raveendran@mayadata.io>