### PR TITLE
(refactor): Rename drain_node experiment to node_drain

### DIFF
--- a/docs/chaoshub.md
+++ b/docs/chaoshub.md
@@ -35,7 +35,7 @@ Chaos actions that apply to generic Kubernetes resources are classified into thi
 | CPU Hog | Exhaust CPU resources on the Kubernetes Node | [cpu-hog](cpu-hog.md) |
 | Disk Fill | Fillup Ephemeral Storage of a Resource | [disk-fill](disk-fill.md) |
 | Disk Loss | External disk loss from the node | [disk-loss](disk-loss.md)|
-| Drain Node| Drain the node where application pod is scheduled | [drain-node](drain-node.md) |
+| Node Drain| Drain the node where application pod is scheduled | [node-drain](node-drain.md) |
 | Pod CPU Hog | Consume CPU resources on the application container | [pod-cpu-hog](pod-cpu-hog.md) |
 | Pod Network Corruption | Inject Network Packet Corruption Into Application Pod |[pod-network-corruption](pod-network-corruption.md) |
 

--- a/docs/node-drain.md
+++ b/docs/node-drain.md
@@ -18,7 +18,7 @@ sidebar_label: Node Drain
 - Ensure that the node specified in the experiment ENV variable `APP_NODE` (the node which will be drained)  should be cordoned before execution of the chaos experiment (before applying the chaosengine manifest) to ensure that the litmus experiment runner pods are not scheduled on it / subjected to eviction. This can be achieved with the following steps: 
 
   - Get node names against the applications pods: `kubectl get pods -o wide`
-  - Cordon the node `kubectl cordon <nodename> 
+  - Cordon the node `kubectl cordon <nodename>` 
 
 ## Entry Criteria
 

--- a/docs/node-drain.md
+++ b/docs/node-drain.md
@@ -1,7 +1,7 @@
 ---
-id: drain-node
-title: Drain Node Experiment Details
-sidebar_label: Drain Node
+id: node-drain
+title: Node Drain Experiment Details
+sidebar_label: Node Drain
 ---
 ------
 
@@ -15,6 +15,7 @@ sidebar_label: Drain Node
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://raw.githubusercontent.com/litmuschaos/pages/master/docs/litmus-operator-latest.yaml)
 - Ensure that the `drain-node` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/drain-node)
+- Ensure that the `APP_NODE`, the node which is going to drain should be in cordened state before applying the chaosengine manifest by executing `kubectl get nodes` command. If not cordoned then use `kubectl cordon <APP_NODE>` command to cordon the node. This is to prevent litmus job pods from getting scheduled on it.  
 
 ## Entry Criteria
 
@@ -141,7 +142,7 @@ spec:
   # It can be delete/infra
   jobCleanUpPolicy: delete
   experiments:
-    - name: drain-node
+    - name: node-drain
       spec:
         components:
            # set node name
@@ -167,6 +168,6 @@ spec:
 
   `kubectl describe chaosresult nginx-chaos-drain-node -n <application-namespace>`
 
-## Drain Node Experiment Demo [TODO]
+## Node Drain Experiment Demo [TODO]
 
 - A sample recording of this experiment execution is provided here.   

--- a/docs/node-drain.md
+++ b/docs/node-drain.md
@@ -15,7 +15,10 @@ sidebar_label: Node Drain
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://raw.githubusercontent.com/litmuschaos/pages/master/docs/litmus-operator-latest.yaml)
 - Ensure that the `drain-node` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/drain-node)
-- Ensure that the `APP_NODE`, the node which is going to drain should be in cordened state before applying the chaosengine manifest by executing `kubectl get nodes` command. If not cordoned then use `kubectl cordon <APP_NODE>` command to cordon the node. This is to prevent litmus job pods from getting scheduled on it.  
+- Ensure that the node specified in the experiment ENV variable `APP_NODE` (the node which will be drained)  should be cordoned before execution of the chaos experiment (before applying the chaosengine manifest) to ensure that the litmus experiment runner pods are not scheduled on it / subjected to eviction. This can be achieved with the following steps: 
+
+  - Get node names against the applications pods: `kubectl get pods -o wide`
+  - Cordon the node `kubectl cordon <nodename> 
 
 ## Entry Criteria
 

--- a/docs/node-drain.md
+++ b/docs/node-drain.md
@@ -14,7 +14,7 @@ sidebar_label: Node Drain
 ## Prerequisites
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://raw.githubusercontent.com/litmuschaos/pages/master/docs/litmus-operator-latest.yaml)
-- Ensure that the `drain-node` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/drain-node)
+- Ensure that the `node-drain` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/drain-node)
 - Ensure that the node specified in the experiment ENV variable `APP_NODE` (the node which will be drained)  should be cordoned before execution of the chaos experiment (before applying the chaosengine manifest) to ensure that the litmus experiment runner pods are not scheduled on it / subjected to eviction. This can be achieved with the following steps: 
 
   - Get node names against the applications pods: `kubectl get pods -o wide`
@@ -169,7 +169,7 @@ spec:
 
 - Check whether the application is resilient to the node drain, once the experiment (job) is completed. The ChaosResult resource name is derived like this: `<ChaosEngine-Name>-<ChaosExperiment-Name>`.
 
-  `kubectl describe chaosresult nginx-chaos-drain-node -n <application-namespace>`
+  `kubectl describe chaosresult nginx-chaos-node-drain -n <application-namespace>`
 
 ## Node Drain Experiment Demo [TODO]
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -24,7 +24,7 @@
           "disk-fill",
           "disk-loss",
           "cpu-hog",
-	  "drain-node"
+	  "node-drain"
         ]
       },
       {


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Fixes: litmuschaos/litmus#1105

- Rename drain_node experiment to node_drain