### PR TITLE
(docs): Add auxiliaryAppInfo as empty string instead of null in sample engine manifest

### DIFF
--- a/docs/container-kill.md
+++ b/docs/container-kill.md
@@ -136,7 +136,7 @@ spec:
   # It can be app/infra
   chaosType: 'app'
   #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo: 
+  auxiliaryAppInfo: ""
   appinfo:
     appns: default
     applabel: 'app=nginx'

--- a/docs/coredns-pod-delete.md
+++ b/docs/coredns-pod-delete.md
@@ -121,6 +121,8 @@ spec:
     appkind: deployment
   # It can be infra only
   chaosType: 'infra'
+  #ex. values: ns1:name=percona,ns2:run=nginx 
+  auxiliaryAppInfo: ""
   components:
     runner:
        image: "litmuschaos/chaos-executor:1.0.0"

--- a/docs/cpu-hog.md
+++ b/docs/cpu-hog.md
@@ -122,7 +122,7 @@ spec:
   # It can be app/infra
   chaosType: 'infra'
   #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo:
+  auxiliaryAppInfo: ""
   chaosServiceAccount: nginx-sa
   monitoring: false
   components:

--- a/docs/disk-fill.md
+++ b/docs/disk-fill.md
@@ -185,7 +185,7 @@ spec:
   # It can be app/infra
   chaosType: 'infra'
   #ex. values: ns1:name=percona,ns2:run=nginx  
-  auxiliaryAppInfo: 
+  auxiliaryAppInfo: ""
   appinfo:
     appns: default
     applabel: 'app=nginx'

--- a/docs/disk-loss.md
+++ b/docs/disk-loss.md
@@ -214,7 +214,7 @@ spec:
   # It can be app/infra
   chaosType: 'infra' 
   #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo: 
+  auxiliaryAppInfo: ""
   appinfo:
     appns: default
     applabel: 'app=nginx'

--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -151,7 +151,7 @@ spec:
   # It can be app/infra
   chaosType: 'app'
   #ex. values: ns1:name=percona,ns2:run=nginx  
-  auxiliaryAppInfo: 
+  auxiliaryAppInfo: ""
   components:
     runner:
       image: "litmuschaos/chaos-executor:1.0.0"

--- a/docs/kafka-broker-disk-failure.md
+++ b/docs/kafka-broker-disk-failure.md
@@ -140,7 +140,7 @@ spec:
   # It can be app/infra
   chaosType: 'app'
   #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo: 
+  auxiliaryAppInfo: ""
   appinfo: 
     appns: default
     applabel: 'app=cp-kafka'

--- a/docs/kafka-broker-pod-failure.md
+++ b/docs/kafka-broker-pod-failure.md
@@ -141,7 +141,7 @@ spec:
   # It can be app/infra
   chaosType: 'app'
   #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo: 
+  auxiliaryAppInfo: ""
   appinfo: 
     appns: default
     applabel: 'app=cp-kafka'

--- a/docs/node-drain.md
+++ b/docs/node-drain.md
@@ -131,7 +131,7 @@ spec:
   # It can be app/infra
   chaosType: 'infra' 
   #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo: 
+  auxiliaryAppInfo: ""
   appinfo:
     appns: default
     applabel: 'app=nginx'

--- a/docs/pod-cpu-hog.md
+++ b/docs/pod-cpu-hog.md
@@ -139,7 +139,7 @@ spec:
   # It can be app/infra
   chaosType: 'app'
   #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo: 
+  auxiliaryAppInfo: ""
   appinfo:
     appns: default
     applabel: 'app=nginx'

--- a/docs/pod-delete.md
+++ b/docs/pod-delete.md
@@ -120,7 +120,7 @@ spec:
   # It can be app/infra
   chaosType: 'app'   
   #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo:  
+  auxiliaryAppInfo: ""
   chaosServiceAccount: nginx-sa
   monitoring: false
   components:

--- a/docs/pod-network-corruption.md
+++ b/docs/pod-network-corruption.md
@@ -162,7 +162,7 @@ spec:
   # It can be app/infra
   chaosType: 'app' 
   #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo: 
+  auxiliaryAppInfo: ""
   monitoring: false
   components:
     runner:

--- a/docs/pod-network-latency.md
+++ b/docs/pod-network-latency.md
@@ -118,7 +118,7 @@ spec:
   # It can be app/infra
   chaosType: 'app'
   #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo:
+  auxiliaryAppInfo: ""
   monitoring: false
   components:
     runner:

--- a/docs/pod-network-loss.md
+++ b/docs/pod-network-loss.md
@@ -118,7 +118,7 @@ spec:
   # It can be app/infra
   chaosType: 'app'
   #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo:
+  auxiliaryAppInfo: ""
   monitoring: false
   components:
     runner:


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Update docs of all generic, coredns, and kafka experiments :
    - Add auxiliaryAppInfo as null string instead of leaving it blank