### PR TITLE
(Docs): Add service-account details in openebs-pool-container-failure

### DIFF
--- a/docs/openebs-pool-container-failure.md
+++ b/docs/openebs-pool-container-failure.md
@@ -11,6 +11,8 @@ sidebar_label: Pool Container Failure
 | ----------| ------------------------ | ------------------------------------------------------------------|
 | OpenEBS   | Kill the cstor pool pod container and check if gets created again | GKE, Konvoy(AWS), Packet(Kubeadm), Minikube, OpenShift(Baremetal)  |
 
+<b>Note:</b> In this example, we are using nginx as stateful application that stores static pages on a Kubernetes volume.
+
 ## Prerequisites
 
 - Ensure that the Litmus Chaos Operator is running in the cluster. If not, install from [here](https://github.com/litmuschaos/chaos-operator/blob/master/deploy/operator.yaml)
@@ -66,9 +68,53 @@ If the experiment tunable DATA_PERSISTENCE is set to 'enabled':
 
 - Follow the steps in the sections below to prepare the ChaosEngine & execute the experiment.
 
+### Prepare chaosServiceAccount
+
+Use this sample RBAC manifest to create a chaosServiceAccount in the desired (app) namespace. This example consists of the minimum necessary cluster role permissions to execute the experiment.
+
+#### Sample Rbac Manifest
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-sa
+  namespace: default
+  labels:
+    name: nginx-sa
+---
+# Source: openebs/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: nginx-sa
+  labels:
+    name: nginx-sa
+rules:
+- apiGroups: ["","apps","litmuschaos.io","batch","extensions","storage.k8s.io",openebs.io"]
+  resources: ["pods","jobs","daemonsets","replicasets","pods/exec","configmaps","secrets","persistentvolumeclaims","cstorvolumereplicas","chaosexperiments","chaosresults","chaosengines"]
+  verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: nginx-sa
+  labels:
+    name: nginx-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-sa
+subjects:
+- kind: ServiceAccount
+  name: nginx-sa
+  namespace: default
+```
+
 ### Prepare ChaosEngine
 
 - Provide the application info in `spec.appinfo`
+- Provide the auxiliary applications info (ns & labels) in `spec.auxiliaryAppInfo`
 - Override the experiment tunables if desired
 
 #### Supported Experiment Tunables
@@ -90,12 +136,21 @@ metadata:
   name: target-chaos
   namespace: default
 spec:
+  # It can be app/infra
+  chaosType: 'infra' 
+  #ex. values: ns1:name=percona,ns2:run=nginx 
+  auxiliaryAppInfo: ""
   appinfo:
     appns: default
-    applabel: 'app=percona'
+    applabel: 'app=nginx'
     appkind: deployment
-  chaosServiceAccount: percona-sa
+  chaosServiceAccount: nginx-sa
   monitoring: false
+  components:
+    runner:
+      image: "litmuschaos/chaos-executor:1.0.0"
+      type: "go"
+  # It can be delete/infra
   jobCleanUpPolicy: delete
   experiments:
     - name: openebs-pool-container-failure


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Updating the service account sample in openebs-pool-container-failure

- Update the sample engine manifest in openebs-pool-container-failure

- Fixes: litmuschaos/litmus#1147