### PR TITLE
(Refactor): Typo Fix in the repeated properties of sample engine spec

### DIFF
--- a/docs/cpu-hog.md
+++ b/docs/cpu-hog.md
@@ -113,16 +113,14 @@ metadata:
   name: nginx-chaos
   namespace: default
 spec:
-  chaosType: 'infra'  # It can be app/infra
-  auxiliaryAppInfo: "ns1:name=percona,ns2:run=nginx"
+# It can be app/infra
+  chaosType: 'infra'  
+#ex. values: ns1:name=percona,ns2:run=nginx 
+  auxiliaryAppInfo: ""
   appinfo:
     appns: default
     applabel: 'app=nginx'
     appkind: deployment
-  # It can be app/infra
-  chaosType: 'infra'
-  #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo: ""
   chaosServiceAccount: nginx-sa
   monitoring: false
   components:

--- a/docs/cpu-hog.md
+++ b/docs/cpu-hog.md
@@ -113,9 +113,9 @@ metadata:
   name: nginx-chaos
   namespace: default
 spec:
-# It can be app/infra
+  # It can be app/infra
   chaosType: 'infra'  
-#ex. values: ns1:name=percona,ns2:run=nginx 
+  #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ""
   appinfo:
     appns: default
@@ -165,3 +165,4 @@ spec:
 ## Application Pod Failure Demo
 
 - A sample recording of this experiment execution is provided here.   
+


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>

This pr is for typo fixing in the sample chaos engine snippet - Removing the repeated properties from the ChaosEngine spec   