### PR TITLE
(Docs): Remove unnecessary comment from all genric/kafka/coredns exp

### DIFF
--- a/docs/container-kill.md
+++ b/docs/container-kill.md
@@ -60,7 +60,6 @@ metadata:
   labels:
     name: nginx-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/docs/coredns-pod-delete.md
+++ b/docs/coredns-pod-delete.md
@@ -54,7 +54,6 @@ metadata:
   labels:
     name: coredns-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/docs/cpu-hog.md
+++ b/docs/cpu-hog.md
@@ -58,7 +58,6 @@ metadata:
   labels:
     name: nginx-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/docs/disk-fill.md
+++ b/docs/disk-fill.md
@@ -97,7 +97,6 @@ metadata:
   labels:
     name: nginx-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/docs/disk-loss.md
+++ b/docs/disk-loss.md
@@ -78,7 +78,6 @@ metadata:
   labels:
     name: nginx-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/docs/kafka-broker-disk-failure.md
+++ b/docs/kafka-broker-disk-failure.md
@@ -69,7 +69,6 @@ metadata:
   labels:
     name: kafka-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/docs/kafka-broker-pod-failure.md
+++ b/docs/kafka-broker-pod-failure.md
@@ -68,7 +68,6 @@ metadata:
   labels:
     name: kafka-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/docs/node-drain.md
+++ b/docs/node-drain.md
@@ -59,7 +59,6 @@ metadata:
   labels:
     name: nginx-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/docs/pod-cpu-hog.md
+++ b/docs/pod-cpu-hog.md
@@ -57,7 +57,6 @@ metadata:
   labels:
     name: nginx-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/docs/pod-delete.md
+++ b/docs/pod-delete.md
@@ -56,7 +56,6 @@ metadata:
   labels:
     name: nginx-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/docs/pod-network-corruption.md
+++ b/docs/pod-network-corruption.md
@@ -57,7 +57,6 @@ metadata:
   labels:
     name: nginx-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/docs/pod-network-latency.md
+++ b/docs/pod-network-latency.md
@@ -58,7 +58,6 @@ metadata:
   labels:
     name: nginx-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:

--- a/docs/pod-network-loss.md
+++ b/docs/pod-network-loss.md
@@ -56,7 +56,6 @@ metadata:
   labels:
     name: nginx-sa
 ---
-# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Remove the unnecessary comment from the all generic/kafka/coredns experiments