### PR TITLE
(refactor): Changing name of cpu_hog experiment to node_cpu_hog

### DIFF
--- a/docs/chaoshub.md
+++ b/docs/chaoshub.md
@@ -32,7 +32,7 @@ Chaos actions that apply to generic Kubernetes resources are classified into thi
 | Pod Delete | Fail the application pod | [pod-delete](pod-delete.md) |
 | Pod Network Latency | Experiment to inject network latency to the POD | [pod-network-latency](pod-network-latency.md) |
 | Pod Network Loss | Experiment to inject network loss to the POD | [pod-network-loss](pod-network-loss.md) |
-| CPU Hog | Exhaust CPU resources on the Kubernetes Node | [cpu-hog](cpu-hog.md) |
+| Node CPU Hog | Exhaust CPU resources on the Kubernetes Node | [nod-cpu-hog](node-cpu-hog.md) |
 | Disk Fill | Fillup Ephemeral Storage of a Resource | [disk-fill](disk-fill.md) |
 | Disk Loss | External disk loss from the node | [disk-loss](disk-loss.md)|
 | Node Drain| Drain the node where application pod is scheduled | [node-drain](node-drain.md) |

--- a/docs/disk-fill.md
+++ b/docs/disk-fill.md
@@ -236,6 +236,6 @@ spec:
 
   `kubectl describe chaosresult nginx-chaos-disk-fill -n <application-namespace>`
 
-## Application Container Kill Demo [TODO]
+## Disk Fill Experiment Demo [TODO]
 
 - A sample recording of this experiment execution is provided here.

--- a/docs/disk-loss.md
+++ b/docs/disk-loss.md
@@ -285,3 +285,7 @@ spec:
 -   Check whether the application is resilient to the disk loss, once the experiment (job) is completed. The ChaosResult resource name is derived like this: <ChaosEngine-Name>-<ChaosExperiment-Name>.
 
 `kubectl describe chaosresult nginx-chaos-disk-loss -n <CHAOS_NAMESPACE>`
+
+## Disk Loss Experiment Demo [TODO]
+
+- A sample recording of this experiment execution is provided here.

--- a/docs/node-cpu-hog.md
+++ b/docs/node-cpu-hog.md
@@ -1,7 +1,7 @@
 ---
-id: cpu-hog
-title: CPU Hog Experiment Details
-sidebar_label: CPU Hog
+id: node-cpu-hog
+title: Node CPU Hog Experiment Details
+sidebar_label: Node CPU Hog
 ---
 ------
 
@@ -23,7 +23,7 @@ sidebar_label: CPU Hog
 ## Prerequisites
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://raw.githubusercontent.com/litmuschaos/pages/master/docs/litmus-operator-latest.yaml)
-- Ensure that the `cpu-hog` experiment resource is available in the cluster  by executing                         `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/cpu-hog)
+- Ensure that the `node-cpu-hog` experiment resource is available in the cluster  by executing                         `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/node-cpu-hog)
 - There should be administrative access to the platform on which the Kubernetes cluster is hosted, as the recovery of the affected node could be manual. For example, gcloud access to the GKE project
 ## Entry Criteria
 
@@ -165,7 +165,7 @@ spec:
   # It can be delete/retain
   jobCleanUpPolicy: delete
   experiments:
-    - name: cpu-hog
+    - name: node-cpu-hog
       spec:
         components:
            # set chaos duration (in sec) as desired
@@ -195,9 +195,8 @@ spec:
 
 - Check whether the application is resilient to the CPU hog, once the experiment (job) is completed. The ChaosResult resource name is derived like this: `<ChaosEngine-Name>-<ChaosExperiment-Name>`.
 
-  `kubectl describe chaosresult nginx-chaos-cpu-hog -n <application-namespace>`
+  `kubectl describe chaosresult nginx-chaos-node-cpu-hog -n <application-namespace>`
 
-## Application Pod Failure Demo
+## Node Cpu Hog Demo [TODO]
 
-- A sample recording of this experiment execution is provided here.   
-
+- A sample recording of this experiment execution is provided here.

--- a/docs/pod-cpu-hog.md
+++ b/docs/pod-cpu-hog.md
@@ -202,4 +202,4 @@ spec:
 
 ## Pod CPU Hog Experiment Demo 
 
-- A sample recording of this experiment execution is provided [here](https://youtu.be/MBGSPmZKb2I).   
+- A sample recording of this experiment execution is provided [here](https://youtu.be/MBGSPmZKb2I).

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -19,12 +19,12 @@
           "container-kill",
           "pod-network-latency",
           "pod-network-loss",
-	  "pod-network-corruption",
-	  "pod-cpu-hog",
+	        "pod-network-corruption",
+	        "pod-cpu-hog",
           "disk-fill",
           "disk-loss",
-          "cpu-hog",
-	  "node-drain"
+          "node-cpu-hog",
+	        "node-drain"
         ]
       },
       {


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Rename cpu-hog experiment to node-cpu-hog

- fixes: litmuschaos/litmus#1177