### PR TITLE
(docs): Adding cStor pool validation steps

### DIFF
--- a/docs/cstor-pool-pod-validation.md
+++ b/docs/cstor-pool-pod-validation.md
@@ -1,0 +1,214 @@
+---
+id: cStor-pool-pod-validation
+title: cStor Pool Pod Validation Experiment Details
+sidebar_label: cStor Pool Pod Validation
+---
+------
+
+## Experiment Metadata
+
+<table>
+  <tr>
+    <th> Type </th>
+    <th> Description </th>
+    <th> Tested K8s Platform </th>
+  </tr>
+  <tr>
+    <td> OpenEBS </td>
+    <td> Fail the cStor pool pod </td>
+    <td> GKE, Konvoy(AWS), Packet(Kubeadm), Minikube </td>
+  </tr>
+</table>
+
+## Prerequisites (pod-delete)
+
+- Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`).If not, install from [here](https://raw.githubusercontent.com/litmuschaos/pages/master/docs/litmus-operator-latest.yaml)
+- Ensure that the `pod-delete` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the openebs namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/pod-delete)
+
+## Entry Criteria
+
+- cStor pool pods are healthy before chaos injection
+
+## Exit Criteria
+
+- cStor pool pods are healthy post chaos injection
+
+## Details
+
+- Causes (forced/graceful) pod failure of specific/random replicas of an application resources
+- Tests deployment sanity (replica availability & uninterrupted service) and recovery workflow of the application
+- The pod delete by `Powerfulseal` is only supporting single pod failure (kill_count = 1)
+
+## Integrations
+
+- Pod failures can be effected using one of these chaos libraries: `litmus`, `powerfulseal`
+- The desired chaos library can be selected by setting one of the above options as value for the env variable `LIB`
+
+## Steps to Execute the Chaos Experiment
+
+- This Chaos Experiment can be triggered by creating a ChaosEngine resource on the cluster. To understand the values to provide in a ChaosEngine specification, refer [Getting Started](getstarted.md/#prepare-chaosengine)
+
+- Follow the steps in the sections below to create the chaosServiceAccount, prepare the ChaosEngine & execute the experiment.
+
+### Prepare chaosServiceAccount
+
+- Use this sample RBAC manifest to create a chaosServiceAccount in the desired (app) namespace. This example consists of the minimum necessary role permissions to execute the experiment.
+
+#### Sample Rbac Manifest
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-sa
+  namespace: openebs
+  labels:
+    name: nginx-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: nginx-sa
+  namespace: openebs
+  labels:
+    name: nginx-sa
+rules:
+- apiGroups: ["","litmuschaos.io","batch","apps"]
+  resources: ["pods","deployments","jobs","configmaps","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update","delete"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs : ["get","list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: nginx-sa
+  namespace: openebs
+  labels:
+    name: nginx-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-sa
+subjects:
+- kind: ServiceAccount
+  name: nginx-sa
+  namespace: openebs
+
+```
+
+### Prepare ChaosEngine
+
+- Provide the cStor pool deployment info in `spec.appinfo`
+- Override the experiment tunables if desired
+
+#### Supported Experiment Tunables
+
+<table>
+  <tr>
+    <th> Variables </th>
+    <th> Description  </th>
+    <th> Type </th>
+    <th> Notes </th>
+  </tr>
+  <tr>
+    <td> TOTAL_CHAOS_DURATION </td>
+    <td> The time duration for chaos insertion (seconds) </td>
+    <td> Optional </td>
+    <td> Defaults to 15s </td>
+  </tr>
+  <tr>
+    <td> CHAOS_INTERVAL </td>
+    <td> Time interval b/w two successive pod failures (sec) </td>
+    <td> Optional </td>
+    <td> Defaults to 5s </td>
+  </tr>
+  <tr>
+    <td> LIB </td>
+    <td> The chaos lib used to inject the chaos </td>
+    <td> Optional  </td>
+    <td> Defaults to `litmus`. Supported: `litmus`, `powerfulseal` </td>
+  </tr>
+  <tr>
+    <td> FORCE  </td>
+    <td> Application Pod failures type </td>
+    <td> Optional  </td>
+    <td> Default to `true`, With `terminationGracePeriodSeconds=0`  </td>
+  </tr>
+  <tr>
+    <td> KILL_COUNT </td>
+    <td> No. of cStor pool pods to be deleted </td>
+    <td> Optional  </td>
+    <td> Default to `1`, kill_count > 1 is only supported by litmus lib , not by the powerfulseal </td>
+  </tr>
+  <tr>
+    <td> RAMP_TIME </td>
+    <td> Period to wait before injection of chaos in sec </td>
+    <td> Optional  </td>
+    <td> </td>
+  </tr>
+</table>
+
+#### Sample ChaosEngine Manifest
+
+```yaml
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: openebs
+spec:
+  appinfo:
+    appns: 'openebs'
+    applabel: 'app=cstor-pool'
+    appkind: 'deployment'
+  # It can be true/false
+  annotationCheck: 'false'  
+  #ex. values: ns1:name=percona,ns2:run=nginx 
+  auxiliaryAppInfo: ''
+  chaosServiceAccount: nginx-sa
+  monitoring: false
+  components:
+    runner:
+      image: 'litmuschaos/chaos-executor:1.0.0'
+      type: 'go'
+  # It can be delete/retain
+  jobCleanUpPolicy: 'delete' 
+  experiments:
+    - name: pod-delete
+      spec:
+        components:
+          env:
+            # set chaos duration (in sec) as desired
+            - name: TOTAL_CHAOS_DURATION
+              value: '30'
+            # set chaos interval (in sec) as desired
+            - name: CHAOS_INTERVAL
+              value: '10'
+            # pod failures without '--force' & default terminationGracePeriodSeconds
+            - name: FORCE
+              value: 'false'
+```
+
+### Create the ChaosEngine Resource
+
+- Create the ChaosEngine manifest prepared in the previous step to trigger the Chaos.
+
+  `kubectl apply -f chaosengine.yml`
+
+### Watch Chaos progress
+
+- View pod terminations & recovery by setting up a watch on the pods in the openebs namespace
+
+  `watch -n 1 kubectl get pods -n openebs`
+
+### Check Chaos Experiment Result
+
+- Check whether the cStor pool pod is resilient to the pod failure, once the experiment (job) is completed. The ChaosResult resource name is derived like this: `<ChaosEngine-Name>-<ChaosExperiment-Name>`.
+
+  `kubectl describe chaosresult nginx-chaos-pod-delete -n openebs`
+
+## cStor Pool Pod Failure Demo
+
+- A sample recording of this experiment execution is provided [here](https://youtu.be/X3JvY_58V9A)


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Adding docs for cStor pool pod validation steps:
    - using `openebs-pool-pod-failure` experiment