### PR TITLE
(fix)change the getting started docs to work with a custom ns instead of default

### DIFF
--- a/website/versioned_docs/version-1.1.0/getstarted.md
+++ b/website/versioned_docs/version-1.1.0/getstarted.md
@@ -38,7 +38,7 @@ Running chaos on your application involves the following steps:
 kubectl apply -f https://litmuschaos.github.io/pages/litmus-operator-v1.1.0.yaml
 ```
 
-The above command install all the CRDs, required service account configuration, and chaos-operator. Before you start running a chaos experiment, verify if your Litmus is installed correctly.
+The above command install all the CRDs, required service account configuration, and chaos-operator. Before you start running a chaos experiment, verify if Litmus is installed correctly.
 
 **Verify your installation**
 
@@ -89,42 +89,55 @@ Expected output:
 
  
 
-<div class="danger">
-<strong>NOTE</strong>: 
-In this guide, we shall describe the steps to inject chaos on an application
-already deployed in the default namespace. It is a mandatory requirement to ensure that the 
-chaosexperiment & chaosengine custom resoures are created in the same namespace (typically, 
-the same as the namespace of the application under test (AUT).
-</div>
+**NOTE**: 
+
+- In this guide, we shall describe the steps to inject container-kill chaos on an nginx application already deployed in the 
+nginx namespace. It is a mandatory requirement to ensure that the chaos custom resources (chaosexperiment and chaosengine) 
+and the experiment specific serviceaccount are created in the same namespace (typically, the same as the namespace of the 
+application under test (AUT), in this case nginx). This is done to ensure that the developers/users of the experiment isolate 
+the chaos to their respective work-namespaces in shared environments. 
+
+- In all subsequent steps, please follow these instructions by replacing the nginx namespace and labels with that of your 
+application.
 
 ### Install Chaos Experiments
 
-Chaos experiments contain the actual chaos details. These experiments are installed on your cluster as Kubernetes CRs (Custom Resources). The Chaos Experiments are grouped as Chaos Charts and are published on <a href=" https://hub.litmuschaos.io" target="_blank">Chaos Hub</a>. 
+Chaos experiments contain the actual chaos details. These experiments are installed on your cluster as Kubernetes CRs. 
+The Chaos Experiments are grouped as Chaos Charts and are published on <a href=" https://hub.litmuschaos.io" target="_blank">Chaos Hub</a>. 
 
-The generic chaos experiments such as `pod-kill`,  `container-kill`,` network-delay` are available under Generic Chaos Chart. This is the first chart you install. You can later install application specific chaos charts for running application oriented chaos.
+The generic chaos experiments such as `pod-delete`,  `container-kill`,` pod-network-latency` are available under Generic Chaos Chart. 
+This is the first chart you are recommended to install. 
 
 ```
-kubectl apply -f https://hub.litmuschaos.io/api/chaos?file=charts/generic/experiments.yaml
+kubectl apply -f https://hub.litmuschaos.io/api/chaos?file=charts/generic/experiments.yaml -n nginx
 ```
 
 Verify if the chaos experiments are installed.
 
 ```
-kubectl get chaosexperiments 
+kubectl get chaosexperiments -n nginx
 ```
 
 ### Setup Service Account
 
-A Service Account should be created to allow chaosengine to run experiments in your application namespace. Copy the following into `rbac.yaml` and run `kubectl apply -f rbac.yaml` to create one such account on your default namespace. You can change the service account name and namespace as needed.
+A service account should be created to allow chaosengine to run experiments in your application namespace. Copy the following 
+into a `rbac.yaml` manifest and run `kubectl apply -f rbac.yaml` to create one such account on the nginx namespace. This serviceaccount 
+has just enough permissions needed to run the container-kill chaos experiment.
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/container-kill/rbac.yaml yaml)
+**NOTE**: 
+
+- For rbac samples corresponding to other experiments such as, say, pod-delete, please refer the respective experiment folder in 
+the [chaos-charts](https://github.com/litmuschaos/chaos-charts/tree/master/charts/generic/pod-delete) repository.  
+
+
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/container-kill/rbac_nginx_getstarted.yaml yaml)
 ```yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: container-kill-sa
-  namespace: default
+  namespace: nginx
   labels:
     name: container-kill-sa
 ---
@@ -132,7 +145,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: container-kill-sa
-  namespace: default
+  namespace: nginx
   labels:
     name: container-kill-sa
 rules:
@@ -144,7 +157,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: container-kill-sa
-  namespace: default
+  namespace: nginx
   labels:
     name: container-kill-sa
 roleRef:
@@ -154,43 +167,48 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: container-kill-sa
-  namespace: default
+  namespace: nginx
 
 ```
 
 ### Annotate your application
 
-Your application has to be annotated with `litmuschaos.io/chaos="true"`. As a security measure, Chaos Operator checks for this annotation on the application before invoking chaos experiment(s) on the application. Replace `nginx` with the name of your deployment.
+Your application has to be annotated with `litmuschaos.io/chaos="true"`. As a security measure, and also as a means 
+to reduce blast radius the chaos operator checks for this annotation before invoking chaos experiment(s) on the application. 
+Replace `nginx` with the name of your deployment.
+
+<div class="danger">
+<strong>NOTE</strong>: 
+Litmus supports chaos on deployments, statefulsets & daemonsets. This example refers to a nginx deploymemt. In case
+of other types, please use the appropriate resource/resource-name convention (say, `sts/kafka` or `ds/node-device-manager`, for example).  
+</div>
 
 ```console
-kubectl annotate deploy/nginx litmuschaos.io/chaos="true"
+kubectl annotate deploy/nginx litmuschaos.io/chaos="true" -n nginx
 ```
 
 ### Prepare ChaosEngine 
 
-ChaosEngine connects application to the Chaos Experiment. Copy the following YAML snippet into a file called `chaosengine.yaml` and update the values of `applabel` , `appns`, `appkind` and `experiments` as per your choice. Toggle `monitoring` between `true`/`false`, to allow the chaos-exporter to fetch experiment related metrics. Change the `chaosServiceAccount` to the name of Service Account created in above step, if applicable.
+ChaosEngine connects the application instance to a Chaos Experiment. Copy the following YAML snippet into a file called 
+`chaosengine.yaml` and update the values of `applabel` , `appns`, `appkind` and `experiments` as per your choice. 
+Change the `chaosServiceAccount` to the name of service account created in above previous steps.
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/container-kill/engine.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/container-kill/engine_nginx_getstarted.yaml yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
   name: nginx-chaos
-  namespace: default
+  namespace: nginx
 spec:
-  # It can be true/false
   annotationCheck: 'true'
-  # It can be active/stop
   engineState: 'active'
-  #ex. values: ns1:name=percona,ns2:run=nginx 
-  auxiliaryAppInfo: ''
   appinfo:
-    appns: 'default'
+    appns: 'nginx'
     applabel: 'app=nginx'
     appkind: 'deployment'
   chaosServiceAccount: container-kill-sa
-  monitoring: false
-  # It can be delete/retain
+  # use retain to keep the job for debug
   jobCleanUpPolicy: 'delete' 
   experiments:
     - name: container-kill
@@ -204,7 +222,9 @@ spec:
 
 ### Override Default Chaos Experiments Variables
 
-After LitmusChaos v1.1.0, to override the default environment variables in chaosExperiments, add the entry of those variables with the same name under `experiments.<experiment_name>.spec.components.env` with the overriding value.
+From LitmusChaos v1.1.0, the default environment variable values in chaosexperiments can be overridden by specifying
+them in the chaosengine under `experiments.<experiment_name>.spec.components.env` with the desired value. In the
+example below, the TARGET_CONTAINER is being set to a desired value based on the application instance. 
 
 ```console
 ...
@@ -233,7 +253,7 @@ Describe the ChaosResult CR to know the status of each experiment. The ```spec.v
 <strong> NOTE:</strong>  ChaosResult CR name will be `<chaos-engine-name>-<chaos-experiment-name>`
 
 ```console
-kubectl describe chaosresult engine-nginx-container-kill
+kubectl describe chaosresult nginx-chaos-container-kill -n nginx
 ```
 
 ## Uninstallation


### PR DESCRIPTION
- Usage of default ns is considered a strict no in most environments. The example has been modified to show the steps to inject chaos on an app that resides in its own namespace. 

Signed-off-by: ksatchit <ksatchit@mayadata.io>