### PR TITLE
(refactor): Rename the openebs control plane validation & cStor-pool-validation exp

### DIFF
--- a/docs/cstor-pool-chaos.md
+++ b/docs/cstor-pool-chaos.md
@@ -1,7 +1,7 @@
 ---
-id: cStor-pool-validation
-title: cStor Pool Validation Experiment Details
-sidebar_label: cStor Pool Validation
+id: cStor-pool-chaos
+title: cStor Pool Chaos Experiment Details
+sidebar_label: cStor Pool Chaos
 ---
 ------
 
@@ -23,7 +23,7 @@ sidebar_label: cStor Pool Validation
 ## Prerequisites
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`).If not, install from [here](https://raw.githubusercontent.com/litmuschaos/pages/master/docs/litmus-operator-latest.yaml)
-- Ensure that the `openebs-pool-pod-failure` experiment resource is available in the cluster by executing `kubectl get chaosexperiments -n openebs` in the openebs namespace. If not, install from [here](https://hub.litmuschaos.io/charts/openebs/experiments/openebs-pool-pod-validation)
+- Ensure that the `openebs-pool-pod-failure` experiment resource is available in the cluster by executing `kubectl get chaosexperiments -n openebs` in the openebs namespace. If not, install from [here](https://hub.litmuschaos.io/charts/openebs/experiments/openebs-pool-pod-failure)
 
 ## Entry Criteria
 
@@ -59,18 +59,18 @@ sidebar_label: cStor Pool Validation
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: openebs-sa
+  name: cStor-pool-chaos-sa
   namespace: openebs
   labels:
-    name: openebs-sa
+    name: cStor-pool-chaos-sa
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  name: openebs-sa
+  name: cStor-pool-chaos-sa
   namespace: openebs
   labels:
-    name: openebs-sa
+    name: cStor-pool-chaos-sa
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","deployments","jobs","configmaps","chaosengines","chaosexperiments","chaosresults"]
@@ -82,17 +82,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: openebs-sa
+  name: cStor-pool-chaos-sa
   namespace: openebs
   labels:
-    name: openebs-sa
+    name: cStor-pool-chaos-sa
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: openebs-sa
+  name: cStor-pool-chaos-sa
 subjects:
 - kind: ServiceAccount
-  name: openebs-sa
+  name: cStor-pool-chaos-sa
   namespace: openebs
 ```
 
@@ -130,7 +130,7 @@ subjects:
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
-  name: openebs-chaos
+  name: cStor-pool-chaos
   namespace: openebs
 spec:
   appinfo:
@@ -139,7 +139,7 @@ spec:
     appkind: 'deployment'
   # It can be true/false
   annotationCheck: 'false'
-  chaosServiceAccount: openebs-sa
+  chaosServiceAccount: cStor-pool-chaos-sa
   monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete' 
@@ -172,8 +172,12 @@ spec:
 
 - Check whether the cStor pool pod is resilient to the pod failure, once the experiment (job) is completed. The ChaosResult resource name is derived like this: `<ChaosEngine-Name>-<ChaosExperiment-Name>`.
 
-  `kubectl describe chaosresult openebs-chaos-openebs-pool-pod-failure -n openebs`
+  `kubectl describe chaosresult cStor-pool-chaos-openebs-pool-pod-failure -n openebs`
 
-## cStor Pool Pod Validation Demo
+## Recovery 
+
+- If the verdict of the ChaosResult is `Fail` then please refer [troubleshooting section](https://docs.openebs.io/docs/next/troubleshooting.html#ndm-related).
+
+## cStor Pool Pod Chaos Demo
 
 - A sample recording of this experiment will be available soon.

--- a/docs/openebs-control-plane-chaos.md
+++ b/docs/openebs-control-plane-chaos.md
@@ -1,8 +1,7 @@
 ---
-id: version-1.1.0-openebs-control-plane-validation
-title: OpenEBS Control Plane Validation Experiment Details
-sidebar_label: Control Plane Validation
-original_id: openebs-control-plane-validation
+id: openebs-control-plane-chaos
+title: OpenEBS Control Plane Chaos Experiment Details
+sidebar_label: Control Plane Chaos
 ---
 ------
 
@@ -25,7 +24,7 @@ original_id: openebs-control-plane-validation
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
 
-- Ensure that the `openebs-control-plane-validation` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the `openebs` namespace. If not, install from [here](https://hub.litmuschaos.io/charts/openebs/experiments/openebs-control-plane-validation)
+- Ensure that the `openebs-control-plane-chaos` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the `openebs` namespace. If not, install from [here](https://hub.litmuschaos.io/charts/openebs/experiments/openebs-control-plane-chaos)
 
 ## Entry Criteria
 
@@ -65,7 +64,7 @@ Use this sample RBAC manifest to create a chaosServiceAccount in the desired (op
 
 #### Sample Rbac Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/openebs/openebs-control-plane-validation/rbac.yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/openebs/openebs-control-plane-chaos/rbac.yaml)
 ```yaml
 ---
 apiVersion: v1
@@ -132,7 +131,7 @@ subjects:
 
 #### Sample ChaosEngine Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/openebs/openebs-control-plane-validation/engine.yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/openebs/openebs-control-plane-chaos/engine.yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
@@ -153,7 +152,7 @@ spec:
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:
-    - name: openebs-control-plane-validation
+    - name: openebs-control-plane-chaos
       spec:
         components:
           env:
@@ -162,7 +161,7 @@ spec:
 
             ## Period to wait before injection of chaos  
             - name: RAMP_TIME
-              value: '2'
+              value: '10'
 
             - name: FORCE
               value: ''
@@ -187,8 +186,12 @@ spec:
 
 - Check whether the OpenEBS control plane is resilient to the pod failure, once the experiment (job) is completed. The ChaosResult resource naming convention is: `<ChaosEngine-Name>-<ChaosExperiment-Name>`.
 
-  `kubectl describe chaosresult control-plane-chaos-openebs-control-plane-validation -n openebs`
+  `kubectl describe chaosresult control-plane-chaos-openebs-control-plane-chaos -n openebs`
 
-## OpenEBS Control Plane Validation Demo [TODO]
+## Recovery 
+
+- If the verdict of the ChaosResult is `Fail` then please refer [troubleshooting section](https://docs.openebs.io/docs/next/troubleshooting.html#installation).
+
+## OpenEBS Control Plane Chaos Demo [TODO]
 
 - A sample recording of this experiment execution is provided here.

--- a/docs/openebs-target-container-failure.md
+++ b/docs/openebs-target-container-failure.md
@@ -252,6 +252,10 @@ spec:
 
   `kubectl describe chaosresult target-chaos-openebs-target-container-failure -n <application-namespace>`
 
+## Recovery 
+
+- If the verdict of the ChaosResult is `Fail` then please refer [troubleshooting section](https://docs.openebs.io/docs/next/troubleshooting.html#volume-provisioning).
+
 ## OpenEBS Target Container Failure Demo [TODO]
 
 - A sample recording of this experiment execution is provided here.

--- a/docs/openebs-target-network-delay.md
+++ b/docs/openebs-target-network-delay.md
@@ -263,6 +263,10 @@ spec:
 
   `kubectl describe chaosresult target-chaos-openebs-target-network-delay -n <application-namespace>`
 
+## Recovery 
+
+- If the verdict of the ChaosResult is `Fail` then please refer [troubleshooting section](https://docs.openebs.io/docs/next/troubleshooting.html#volume-provisioning).
+
 ## OpenEBS Target Network Delay Demo [TODO]
 
 - A sample recording of this experiment execution is provided here.

--- a/docs/openebs-target-pod-failure.md
+++ b/docs/openebs-target-pod-failure.md
@@ -235,6 +235,10 @@ spec:
 
   `kubectl describe chaosresult target-chaos-openebs-target-pod-failure -n <application-namespace>`
 
+## Recovery 
+
+- If the verdict of the ChaosResult is `Fail` then please refer [troubleshooting section](https://docs.openebs.io/docs/next/troubleshooting.html#volume-provisioning).
+
 ## OpenEBS Target Pod Failure Demo [TODO]
 
 - A sample recording of this experiment execution is provided here.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -42,8 +42,8 @@
           "openebs-pool-container-failure",
           "openebs-pool-network-delay",
           "openebs-pool-network-loss",
-          "openebs-control-plane-validation",
-          "cStor-pool-validation"
+          "openebs-control-plane-chaos",
+          "cStor-pool-chaos"
         ]
       },
       {

--- a/website/versioned_docs/version-1.1.0/cstor-pool-chaos.md
+++ b/website/versioned_docs/version-1.1.0/cstor-pool-chaos.md
@@ -1,8 +1,8 @@
 ---
-id: version-1.1.0-cStor-pool-validation
-title: cStor Pool Validation Experiment Details
-sidebar_label: cStor Pool Validation
-original_id: cStor-pool-validation
+id: version-1.1.0-cStor-pool-chaos
+title: cStor Pool Chaos Experiment Details
+sidebar_label: cStor Pool Chaos
+original_id: cStor-pool-chaos
 ---
 ------
 
@@ -24,7 +24,7 @@ original_id: cStor-pool-validation
 ## Prerequisites
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`).If not, install from [here](https://raw.githubusercontent.com/litmuschaos/pages/master/docs/litmus-operator-latest.yaml)
-- Ensure that the `openebs-pool-pod-failure` experiment resource is available in the cluster by executing `kubectl get chaosexperiments -n openebs` in the openebs namespace. If not, install from [here](https://hub.litmuschaos.io/charts/openebs/experiments/openebs-pool-pod-validation)
+- Ensure that the `openebs-pool-pod-failure` experiment resource is available in the cluster by executing `kubectl get chaosexperiments -n openebs` in the openebs namespace. If not, install from [here](https://hub.litmuschaos.io/charts/openebs/experiments/openebs-pool-pod-failure)
 
 ## Entry Criteria
 
@@ -60,18 +60,18 @@ original_id: cStor-pool-validation
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: openebs-sa
+  name: cStor-pool-chaos-sa
   namespace: openebs
   labels:
-    name: openebs-sa
+    name: cStor-pool-chaos-sa
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  name: openebs-sa
+  name: cStor-pool-chaos-sa
   namespace: openebs
   labels:
-    name: openebs-sa
+    name: cStor-pool-chaos-sa
 rules:
 - apiGroups: ["","litmuschaos.io","batch","apps"]
   resources: ["pods","deployments","jobs","configmaps","chaosengines","chaosexperiments","chaosresults"]
@@ -83,17 +83,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: openebs-sa
+  name: cStor-pool-chaos-sa
   namespace: openebs
   labels:
-    name: openebs-sa
+    name: cStor-pool-chaos-sa
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: openebs-sa
+  name: cStor-pool-chaos-sa
 subjects:
 - kind: ServiceAccount
-  name: openebs-sa
+  name: cStor-pool-chaos-sa
   namespace: openebs
 ```
 
@@ -131,7 +131,7 @@ subjects:
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
-  name: openebs-chaos
+  name: cStor-pool-chaos
   namespace: openebs
 spec:
   appinfo:
@@ -140,7 +140,7 @@ spec:
     appkind: 'deployment'
   # It can be true/false
   annotationCheck: 'false'
-  chaosServiceAccount: openebs-sa
+  chaosServiceAccount: cStor-pool-chaos-sa
   monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete' 
@@ -173,8 +173,12 @@ spec:
 
 - Check whether the cStor pool pod is resilient to the pod failure, once the experiment (job) is completed. The ChaosResult resource name is derived like this: `<ChaosEngine-Name>-<ChaosExperiment-Name>`.
 
-  `kubectl describe chaosresult openebs-chaos-openebs-pool-pod-failure -n openebs`
+  `kubectl describe chaosresult cStor-pool-chaos-openebs-pool-pod-failure -n openebs`
 
-## cStor Pool Pod Validation Demo
+## Recovery 
+
+- If the verdict of the ChaosResult is `Fail` then please refer [troubleshooting section](https://docs.openebs.io/docs/next/troubleshooting.html#ndm-related).
+
+## cStor Pool Pod Chaos Demo
 
 - A sample recording of this experiment will be available soon.

--- a/website/versioned_docs/version-1.1.0/openebs-control-plane-chaos.md
+++ b/website/versioned_docs/version-1.1.0/openebs-control-plane-chaos.md
@@ -1,7 +1,8 @@
 ---
-id: openebs-control-plane-validation
-title: OpenEBS Control Plane Validation Experiment Details
-sidebar_label: Control Plane Validation
+id: version-1.1.0-openebs-control-plane-chaos
+title: OpenEBS Control Plane Chaos Experiment Details
+sidebar_label: Control Plane Chaos
+original_id: openebs-control-plane-chaos
 ---
 ------
 
@@ -24,7 +25,7 @@ sidebar_label: Control Plane Validation
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
 
-- Ensure that the `openebs-control-plane-validation` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the `openebs` namespace. If not, install from [here](https://hub.litmuschaos.io/charts/openebs/experiments/openebs-control-plane-validation)
+- Ensure that the `openebs-control-plane-chaos` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the `openebs` namespace. If not, install from [here](https://hub.litmuschaos.io/charts/openebs/experiments/openebs-control-plane-chaos)
 
 ## Entry Criteria
 
@@ -64,7 +65,7 @@ Use this sample RBAC manifest to create a chaosServiceAccount in the desired (op
 
 #### Sample Rbac Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/openebs/openebs-control-plane-validation/rbac.yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/openebs/openebs-control-plane-chaos/rbac.yaml)
 ```yaml
 ---
 apiVersion: v1
@@ -131,7 +132,7 @@ subjects:
 
 #### Sample ChaosEngine Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/openebs/openebs-control-plane-validation/engine.yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/openebs/openebs-control-plane-chaos/engine.yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
@@ -152,7 +153,7 @@ spec:
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:
-    - name: openebs-control-plane-validation
+    - name: openebs-control-plane-chaos
       spec:
         components:
           env:
@@ -161,7 +162,7 @@ spec:
 
             ## Period to wait before injection of chaos  
             - name: RAMP_TIME
-              value: '2'
+              value: '10'
 
             - name: FORCE
               value: ''
@@ -186,8 +187,12 @@ spec:
 
 - Check whether the OpenEBS control plane is resilient to the pod failure, once the experiment (job) is completed. The ChaosResult resource naming convention is: `<ChaosEngine-Name>-<ChaosExperiment-Name>`.
 
-  `kubectl describe chaosresult control-plane-chaos-openebs-control-plane-validation -n openebs`
+  `kubectl describe chaosresult control-plane-chaos-openebs-control-plane-chaos -n openebs`
 
-## OpenEBS Control Plane Validation Demo [TODO]
+## Recovery 
+
+- If the verdict of the ChaosResult is `Fail` then please refer [troubleshooting section](https://docs.openebs.io/docs/next/troubleshooting.html#installation).
+
+## OpenEBS Control Plane Chaos Demo [TODO]
 
 - A sample recording of this experiment execution is provided here.

--- a/website/versioned_docs/version-1.1.0/openebs-target-container-failure.md
+++ b/website/versioned_docs/version-1.1.0/openebs-target-container-failure.md
@@ -253,6 +253,10 @@ spec:
 
   `kubectl describe chaosresult target-chaos-openebs-target-container-failure -n <application-namespace>`
 
+## Recovery 
+
+- If the verdict of the ChaosResult is `Fail` then please refer [troubleshooting section](https://docs.openebs.io/docs/next/troubleshooting.html#volume-provisioning).
+
 ## OpenEBS Target Container Failure Demo [TODO]
 
 - A sample recording of this experiment execution is provided here.

--- a/website/versioned_docs/version-1.1.0/openebs-target-network-delay.md
+++ b/website/versioned_docs/version-1.1.0/openebs-target-network-delay.md
@@ -264,6 +264,10 @@ spec:
 
   `kubectl describe chaosresult target-chaos-openebs-target-network-delay -n <application-namespace>`
 
+## Recovery 
+
+- If the verdict of the ChaosResult is `Fail` then please refer [troubleshooting section](https://docs.openebs.io/docs/next/troubleshooting.html#volume-provisioning).
+
 ## OpenEBS Target Network Delay Demo [TODO]
 
 - A sample recording of this experiment execution is provided here.

--- a/website/versioned_docs/version-1.1.0/openebs-target-pod-failure.md
+++ b/website/versioned_docs/version-1.1.0/openebs-target-pod-failure.md
@@ -236,6 +236,10 @@ spec:
 
   `kubectl describe chaosresult target-chaos-openebs-target-pod-failure -n <application-namespace>`
 
+## Recovery 
+
+- If the verdict of the ChaosResult is `Fail` then please refer [troubleshooting section](https://docs.openebs.io/docs/next/troubleshooting.html#volume-provisioning).
+
 ## OpenEBS Target Pod Failure Demo [TODO]
 
 - A sample recording of this experiment execution is provided here.

--- a/website/versioned_sidebars/version-1.1.0-sidebars.json
+++ b/website/versioned_sidebars/version-1.1.0-sidebars.json
@@ -38,8 +38,8 @@
           "version-1.1.0-openebs-pool-container-failure",
           "version-1.1.0-openebs-pool-network-delay",
           "version-1.1.0-openebs-pool-network-loss",
-          "version-1.1.0-openebs-control-plane-validation",
-          "version-1.1.0-cStor-pool-validation"
+          "version-1.1.0-openebs-control-plane-chaos",
+          "version-1.1.0-cStor-pool-chaos"
         ]
       },
       {


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Rename the `openebs-control-plane-validation` to  `openebs-control-plane-chaos`

-  Rename the `cStor-pool-validation` to `cStor-pool-chaos`