### PR TITLE
Adding the link check tool to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ env:
 
 services:
 - docker
+install:
+  - go get -u -v github.com/bmuschko/link-verifier
+before_script:
+  - link-verifier --dirs docs,website,README.md --fail=false
 script:
   - python tag.py
   - cd website


### PR DESCRIPTION
Going ahead with [link-verifier](https://github.com/bmuschko/link-verifier) as the choice of link checking tool.
It is written in Go, is quite fast and accurate.

Currently keeping the tool check not to cause the build failure upon
finding broken links. Build failure will be kept in enforcing mode once
the sanity of document links is in good health.

Remove `--fail=false` flag once it is decided to have enforcing mode enabled.

Other evaluated tools were:
https://github.com/tcort/markdown-link-check
https://github.com/stevenvachon/broken-link-checker
https://github.com/raviqqe/liche