### PR TITLE
update(docs): Rename the generic category to kubernetes

### DIFF
--- a/docs/chaoshub.md
+++ b/docs/chaoshub.md
@@ -16,15 +16,14 @@ To contribute new chaos charts visit: https://github.com/litmuschaos/chaos-chart
 
 Litmus chaos hub is a place where the chaos engineering community members publish their chaos experiments. A set of related chaos experiments are bundled into a `Chaos Chart`. Chaos Charts are classified into the following categories.
 
-- [Generic Chaos](#generic-chaos)
+- [Kubernetes Chaos](#kubernetes-chaos)
 - [Application Chaos](#application-chaos)
 - [Platform Chaos](#platform-chaos)
 
 
+### Kubernetes Chaos 
 
-### Generic Chaos 
-
-Chaos actions that apply to generic Kubernetes resources are classified into this category. Following chaos experiments are supported under Generic Chaos Chart
+Chaos actions that apply to Kubernetes resources are classified into this category. Following chaos experiments are supported under Kubernetes Chaos Chart
 
 | Experiment name | Description                               | User guide link                                         |
 | ----------- | ----------------------------------------- | --------------------------------------------------------- |
@@ -41,7 +40,7 @@ Chaos actions that apply to generic Kubernetes resources are classified into thi
 
 ### Application Chaos
 
-While Chaos Experiments under the Generic category offer the ability to induce chaos into Kubernetes resources, it is difficult to analyze and conclude if the chaos induced found a weakness in a given application. The application specific chaos experiments are built with some checks on *pre-conditions* and some expected outcomes after the chaos injection. The result of the chaos experiment is determined by matching the outcome with the expected outcome. 
+While Chaos Experiments under the Kubernetes category offer the ability to induce chaos into Kubernetes resources, it is difficult to analyze and conclude if the chaos induced found a weakness in a given application. The application specific chaos experiments are built with some checks on *pre-conditions* and some expected outcomes after the chaos injection. The result of the chaos experiment is determined by matching the outcome with the expected outcome. 
 
 <div class="danger">
 <strong>NOTE:</strong> If the result of the chaos experiment is `pass`, it means that the application is resilient to that chaos.

--- a/docs/container-kill.md
+++ b/docs/container-kill.md
@@ -14,7 +14,7 @@ sidebar_label: Container Kill
     <th> Tested K8s Platform </th>
   </tr>
   <tr>
-    <td> Generic </td>
+    <td> Kubernetes </td>
     <td> Kill one container in the application pod </td>
     <td> GKE, Packet(Kubeadm), Minikube </td>
   </tr>
@@ -23,7 +23,7 @@ sidebar_label: Container Kill
 ## Prerequisites
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
-- Ensure that the `container-kill` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/container-kill)
+- Ensure that the `container-kill` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/kubernetes/experiments/container-kill)
 - Cluster should have docker runtime, if the chaos_lib is `pumba`. It should have containerd runtime in cluster, if the chaos_lib is `containerd`.
 
 ## Entry Criteria
@@ -64,7 +64,7 @@ sidebar_label: Container Kill
 
 #### Sample Rbac Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/container-kill/rbac.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/container-kill/rbac.yaml yaml)
 ```yaml
 ---
 apiVersion: v1
@@ -147,7 +147,7 @@ subjects:
 
 #### Sample ChaosEngine Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/container-kill/engine.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/container-kill/engine.yaml yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine

--- a/docs/devguide.md
+++ b/docs/devguide.md
@@ -29,7 +29,7 @@ A group of Choas Experiments put together in a YAML file. Each group or chart ha
 that holds data such as `ChartVersion`, `Contributors`, `Description`, `links` etc.., This metadata is rendered on the ChartHub. 
 A chaos chart also consists of a `package` manifest that is an index of available experiments in the chart.
 
-Here is an example of the [ChartServiceVersion](https://github.com/litmuschaos/chaos-charts/blob/master/charts/generic/generic.chartserviceversion.yaml) & [package](https://github.com/litmuschaos/chaos-charts/blob/master/charts/generic/generic.package.yaml) manifests of the generic chaos chart.
+Here is an example of the [ChartServiceVersion](https://github.com/litmuschaos/chaos-charts/blob/master/charts/kubernetes/kubernetes.chartserviceversion.yaml) & [package](https://github.com/litmuschaos/chaos-charts/blob/master/charts/kubernetes/kubernetes.package.yaml) manifests of the kubernetes chaos chart.
 
 
 ### Chaos Experiment
@@ -38,14 +38,14 @@ ChaosExperiment is a CRD that specifies the nature of a Chaos Experiment. The YA
 is stored under a Chaos Chart of ChaosHub and typically consists of low-level chaos parameters specific to that experiment, set
 to their default values. 
 
-Here is an example chaos experiment CR for a [pod-delete](https://github.com/litmuschaos/chaos-charts/blob/master/charts/generic/pod-delete/experiment.yaml) experiment
+Here is an example chaos experiment CR for a [pod-delete](https://github.com/litmuschaos/chaos-charts/blob/master/charts/kubernetes/pod-delete/experiment.yaml) experiment
 
 ### Litmus Book
 
 Litmus book is an `ansible` playbook that encompasses the logic of pre-checks, chaos-injection, post-checks, and result-updates. 
 Typically, these are accompanied by a Kubernetes job that can execute the respective playbook. 
 
-Here is an example of the litmus book for the [pod-delete](https://github.com/litmuschaos/litmus/tree/master/experiments/generic/pod_delete) experiment.
+Here is an example of the litmus book for the [pod-delete](https://github.com/litmuschaos/litmus/tree/master/experiments/kubernetes/pod_delete) experiment.
 
 ### Chaos functions
 

--- a/docs/disk-fill.md
+++ b/docs/disk-fill.md
@@ -24,7 +24,7 @@ sidebar_label: Disk Fill
 
 - Ensure that Kubernetes Version > 1.13
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
-- Ensure that the `disk-fill` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/disk-fill)
+- Ensure that the `disk-fill` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace If not, install from [here](https://hub.litmuschaos.io/charts/kubernetes/experiments/disk-fill)
 - Cluster must run docker container runtime
 - Appropriate Ephemeral Storage Requests and Limits should be set for the application before running the experiment. 
   An example specification is shown below:
@@ -88,7 +88,7 @@ spec:
 
 #### Sample Rbac Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/disk-fill/rbac.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/disk-fill/rbac.yaml yaml)
 ```yaml
 ---
 apiVersion: v1
@@ -181,7 +181,7 @@ subjects:
 
 #### Sample ChaosEngine Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/disk-fill/engine.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/disk-fill/engine.yaml yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine

--- a/docs/disk-loss.md
+++ b/docs/disk-loss.md
@@ -13,7 +13,7 @@ sidebar_label: Disk Loss
     <th> Tested K8s Platform </th>
   </tr>
   <tr>
-    <td> Generic </td>
+    <td> Kubernetes </td>
     <td> External disk loss from the node </td>
     <td> GKE, AWS(KOPS) </td>
   </tr>
@@ -21,7 +21,7 @@ sidebar_label: Disk Loss
 
 ## Prerequisites
 -   Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
--   Ensure that the `disk-loss` experiment resource is available in the cluster by `kubectl get chaosexperiments` in the desired namespace. If not, install from  <a href="https://hub.litmuschaos.io/charts/generic/experiments/disk-loss" target="_blank">here</a>
+-   Ensure that the `disk-loss` experiment resource is available in the cluster by `kubectl get chaosexperiments` in the desired namespace. If not, install from  <a href="https://hub.litmuschaos.io/charts/kubernetes/experiments/disk-loss" target="_blank">here</a>
 -   Ensure to create a Kubernetes secret having the gcloud/aws access configuration(key) in the namespace of `CHAOS_NAMESPACE`.
 -   There should be administrative access to the platform on which the cluster is hosted, as the recovery of the affected node could be manual. Example gcloud access to the project
 
@@ -69,7 +69,7 @@ stringData:
 
 #### Sample Rbac Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/disk-loss/rbac.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/disk-loss/rbac.yaml yaml)
 ```yaml
 ---
 apiVersion: v1
@@ -210,7 +210,7 @@ subjects:
 
 ## Sample ChaosEngine Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/disk-loss/engine.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/disk-loss/engine.yaml yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine

--- a/docs/faq-general.md
+++ b/docs/faq-general.md
@@ -80,7 +80,7 @@ By default, the Litmus operator uses the “litmus” serviceaccount that is bou
 to watch for the ChaosEngine resource across namespaces. However, the experiments themselves are associated 
 with “chaosServiceAccounts” which are created by the developers with bare-minimum permissions necessary to 
 execute the experiment in question. Visit the [chaos-charts](https://github.com/litmuschaos/chaos-charts) repo 
-to view the experiment-specific rbac permissions. For example, here are the [permissions](https://github.com/litmuschaos/chaos-charts/blob/master/charts/generic/container-kill/rbac.yaml) for container-kill chaos.
+to view the experiment-specific rbac permissions. For example, here are the [permissions](https://github.com/litmuschaos/chaos-charts/blob/master/charts/kubernetes/container-kill/rbac.yaml) for container-kill chaos.
 
 
 ### What is the scope of a Litmus Chaos Experiment? 

--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -104,11 +104,11 @@ application.
 Chaos experiments contain the actual chaos details. These experiments are installed on your cluster as Kubernetes CRs. 
 The Chaos Experiments are grouped as Chaos Charts and are published on <a href=" https://hub.litmuschaos.io" target="_blank">Chaos Hub</a>. 
 
-The generic chaos experiments such as `pod-delete`,  `container-kill`,` pod-network-latency` are available under Generic Chaos Chart. 
+The kubernetes chaos experiments such as `pod-delete`,  `container-kill`,` pod-network-latency` are available under Kubernetes Chaos Chart. 
 This is the first chart you are recommended to install. 
 
 ```
-kubectl apply -f https://hub.litmuschaos.io/api/chaos?file=charts/generic/experiments.yaml -n nginx
+kubectl apply -f https://hub.litmuschaos.io/api/chaos?file=charts/kubernetes/experiments.yaml -n nginx
 ```
 
 Verify if the chaos experiments are installed.
@@ -126,10 +126,10 @@ has just enough permissions needed to run the container-kill chaos experiment.
 **NOTE**: 
 
 - For rbac samples corresponding to other experiments such as, say, pod-delete, please refer the respective experiment folder in 
-the [chaos-charts](https://github.com/litmuschaos/chaos-charts/tree/master/charts/generic/pod-delete) repository.  
+the [chaos-charts](https://github.com/litmuschaos/chaos-charts/tree/master/charts/kubernetes/pod-delete) repository.  
 
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/container-kill/rbac_nginx_getstarted.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/container-kill/rbac_nginx_getstarted.yaml yaml)
 ```yaml
 ---
 apiVersion: v1
@@ -192,7 +192,7 @@ ChaosEngine connects the application instance to a Chaos Experiment. Copy the fo
 `chaosengine.yaml` and update the values of `applabel` , `appns`, `appkind` and `experiments` as per your choice. 
 Change the `chaosServiceAccount` to the name of service account created in above previous steps.
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/container-kill/engine_nginx_getstarted.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/container-kill/engine_nginx_getstarted.yaml yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine

--- a/docs/node-cpu-hog.md
+++ b/docs/node-cpu-hog.md
@@ -14,7 +14,7 @@ sidebar_label: Node CPU Hog
     <th> Tested K8s Platform </th>
   </tr>
   <tr>
-    <td> Generic </td>
+    <td> Kubernetes </td>
     <td> Exhaust CPU resources on the Kubernetes Node </td>
     <td> GKE </td>
   </tr>
@@ -23,7 +23,7 @@ sidebar_label: Node CPU Hog
 ## Prerequisites
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
-- Ensure that the `node-cpu-hog` experiment resource is available in the cluster  by executing                         `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/node-cpu-hog)
+- Ensure that the `node-cpu-hog` experiment resource is available in the cluster  by executing                         `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/kubernetes/experiments/node-cpu-hog)
 - There should be administrative access to the platform on which the Kubernetes cluster is hosted, as the recovery of the affected node could be manual. For example, gcloud access to the GKE project
 ## Entry Criteria
 
@@ -57,7 +57,7 @@ Tests application resiliency upon replica evictions caused due to lack of CPU re
 
 #### Sample Rbac Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/node-cpu-hog/rbac.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/node-cpu-hog/rbac.yaml yaml)
 ```yaml
 ---
 apiVersion: v1
@@ -141,7 +141,7 @@ subjects:
 
 #### Sample ChaosEngine Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/node-cpu-hog/engine.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/node-cpu-hog/engine.yaml yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine

--- a/docs/node-drain.md
+++ b/docs/node-drain.md
@@ -14,7 +14,7 @@ sidebar_label: Node Drain
     <th> Tested K8s Platform </th>
   </tr>
   <tr>
-    <td> Generic </td>
+    <td> Kubernetes </td>
     <td> Drain the node where application pod is scheduled. </td>
     <td> GKE, AWS, Packet(Kubeadm), Konvoy(AWS) </td>
   </tr>
@@ -23,7 +23,7 @@ sidebar_label: Node Drain
 ## Prerequisites
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
-- Ensure that the `node-drain` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/node-drain)
+- Ensure that the `node-drain` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/kubernetes/experiments/node-drain)
 - Ensure that the node specified in the experiment ENV variable `APP_NODE` (the node which will be drained)  should be cordoned before execution of the chaos experiment (before applying the chaosengine manifest) to ensure that the litmus experiment runner pods are not scheduled on it / subjected to eviction. This can be achieved with the following steps: 
 
   - Get node names against the applications pods: `kubectl get pods -o wide`
@@ -58,7 +58,7 @@ Use this sample RBAC manifest to create a chaosServiceAccount in the desired (ap
 
 #### Sample Rbac Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/node-drain/rbac.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/node-drain/rbac.yaml yaml)
 ```yaml
 ---
 apiVersion: v1
@@ -137,7 +137,7 @@ subjects:
                       
 #### Sample ChaosEngine Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/node-drain/engine.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/node-drain/engine.yaml yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine

--- a/docs/pod-cpu-hog.md
+++ b/docs/pod-cpu-hog.md
@@ -14,7 +14,7 @@ sidebar_label: Pod CPU Hog
     <th> Tested K8s Platform </th>
   </tr>
   <tr>
-     <td> Generic </td>
+     <td> Kubernetes </td>
     <td> Consume CPU resources on the application container</td>
     <td> GKE, Packet(Kubeadm), Minikube  </td>
   </tr>
@@ -23,7 +23,7 @@ sidebar_label: Pod CPU Hog
 ## Prerequisites
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
-- Ensure that the `pod-cpu-hog` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/pod-cpu-hog)
+- Ensure that the `pod-cpu-hog` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/kubernetes/experiments/pod-cpu-hog)
 - Cluster must run docker container runtime
 
 ## Entry Criteria
@@ -57,7 +57,7 @@ Use this sample RBAC manifest to create a chaosServiceAccount in the desired (ap
 
 #### Sample Rbac Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-cpu-hog/rbac.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-cpu-hog/rbac.yaml yaml)
 ```yaml
 ---
 apiVersion: v1
@@ -147,7 +147,7 @@ subjects:
                       
 #### Sample ChaosEngine Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-cpu-hog/engine.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-cpu-hog/engine.yaml yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine

--- a/docs/pod-delete.md
+++ b/docs/pod-delete.md
@@ -14,7 +14,7 @@ sidebar_label: Pod Delete
     <th> Tested K8s Platform </th>
   </tr>
   <tr>
-    <td> Generic </td>
+    <td> Kubernetes </td>
     <td> Fail the application pod </td>
     <td> GKE, Konvoy(AWS), Packet(Kubeadm), Minikube </td>
   </tr>
@@ -23,7 +23,7 @@ sidebar_label: Pod Delete
 ## Prerequisites
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`).If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
-- Ensure that the `pod-delete` experiment resource is available in the cluster by executing                         `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/pod-delete)
+- Ensure that the `pod-delete` experiment resource is available in the cluster by executing                         `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/kubernetes/experiments/pod-delete)
 
 ## Entry Criteria
 
@@ -56,7 +56,7 @@ sidebar_label: Pod Delete
 
 #### Sample Rbac Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-delete/rbac.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-delete/rbac.yaml yaml)
 ```yaml
 ---
 apiVersion: v1
@@ -154,7 +154,7 @@ subjects:
 
 #### Sample ChaosEngine Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-delete/engine.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-delete/engine.yaml yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine

--- a/docs/pod-network-corruption.md
+++ b/docs/pod-network-corruption.md
@@ -14,7 +14,7 @@ sidebar_label: Pod Network Corruption
     <th> Tested K8s Platform </th>
   </tr>
   <tr>
-    <td> Generic </td>
+    <td> Kubernetes </td>
     <td> Inject Network Packet Corruption Into Application Pod </td>
     <td> GKE, Packet(Kubeadm), Minikube > v1.6.0 </td>
   </tr>
@@ -22,7 +22,7 @@ sidebar_label: Pod Network Corruption
 
 ## Prerequisites
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
-- Ensure that the `pod-network-corruption` experiment resource is available in the cluster by `kubectl get chaosexperiments` command. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/pod-network-corruption)
+- Ensure that the `pod-network-corruption` experiment resource is available in the cluster by `kubectl get chaosexperiments` command. If not, install from [here](https://hub.litmuschaos.io/charts/kubernetes/experiments/pod-network-corruption)
 -  Cluster must run docker container runtime
 
 <div class="danger">
@@ -57,7 +57,7 @@ sidebar_label: Pod Network Corruption
 
 #### Sample Rbac Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-network-corruption/rbac.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-network-corruption/rbac.yaml yaml)
 ```yaml
 ---
 apiVersion: v1
@@ -157,7 +157,7 @@ subjects:
 
 #### Sample ChaosEngine Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-network-corruption/engine.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-network-corruption/engine.yaml yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine

--- a/docs/pod-network-latency.md
+++ b/docs/pod-network-latency.md
@@ -14,7 +14,7 @@ sidebar_label: Pod Network Latency
    <th> Tested K8s Platform </th>
   </tr>
   <tr>
-    <td> Generic </td>
+    <td> Kubernetes </td>
     <td> Inject Network Latency Into Application Pod </td>
     <td> GKE, Packet(Kubeadm), Minikube > v1.6.0 </td>
   </tr>
@@ -22,7 +22,7 @@ sidebar_label: Pod Network Latency
 
 ## Prerequisites
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
-- Ensure that the `pod-network-latency` experiment resource is available in the cluster by executing kubectl `get chaosexperiments` in the desired namespace. . If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/pod-network-latency)
+- Ensure that the `pod-network-latency` experiment resource is available in the cluster by executing kubectl `get chaosexperiments` in the desired namespace. . If not, install from [here](https://hub.litmuschaos.io/charts/kubernetes/experiments/pod-network-latency)
 
 
 <div class="danger">
@@ -58,7 +58,7 @@ sidebar_label: Pod Network Latency
 
 #### Sample Rbac Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-network-latency/rbac.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-network-latency/rbac.yaml yaml)
 ```yaml
 ---
 apiVersion: v1
@@ -158,7 +158,7 @@ subjects:
 
 #### Sample ChaosEngine Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-network-latency/engine.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-network-latency/engine.yaml yaml)
 ```yaml
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine

--- a/docs/pod-network-loss.md
+++ b/docs/pod-network-loss.md
@@ -14,7 +14,7 @@ sidebar_label: Pod Network Loss
     <th> Tested K8s Platform </th>
   </tr>
   <tr>
-    <td> Generic </td>
+    <td> Kubernetes </td>
     <td> Inject Packet Loss Into Application Pod </td>
     <td> GKE, Packet(Kubeadm), Minikube > v1.6.0 </td>
   </tr>
@@ -23,7 +23,7 @@ sidebar_label: Pod Network Loss
 ## Prerequisites
 
 - Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
-- Ensure that the `pod-network-loss` experiment resource is available in the cluster by executing                         `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/generic/experiments/pod-network-loss)
+- Ensure that the `pod-network-loss` experiment resource is available in the cluster by executing                         `kubectl get chaosexperiments` in the desired namespace. If not, install from [here](https://hub.litmuschaos.io/charts/kubernetes/experiments/pod-network-loss)
   <div class="danger">
     <strong>NOTE</strong>: 
         Experiment is supported only on Docker Runtime. Support for containerd/CRIO runtimes will be added in subsequent releases.
@@ -55,7 +55,7 @@ sidebar_label: Pod Network Loss
 
 #### Sample Rbac Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-network-loss/rbac.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-network-loss/rbac.yaml yaml)
 ```yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -154,7 +154,7 @@ subjects:
 
 #### Sample ChaosEngine Manifest
 
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-network-loss/engine.yaml yaml)
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kubernetes/pod-network-loss/engine.yaml yaml)
 ```yaml
 # chaosengine.yaml
 apiVersion: litmuschaos.io/v1alpha1

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -16,7 +16,7 @@
     "Experiments": [
       {
         "type": "subcategory",
-        "label": "Generic",
+        "label": "Kubernetes",
         "ids": [
           "pod-delete",
           "container-kill",


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

- Rename the generic category to Kubernetes