### PR TITLE
fix1366: Uncommented the title string

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -21,7 +21,7 @@ const users = [
 ];
 
 const siteConfig = {
-  //title: 'Litmus Docs', // Title for your website.
+  title: 'Litmus Docs', // Title for your website.
   tagline: 'A website for testing',
   url: 'https://docs.litmuschaos.io', // Your website URL
   baseUrl: '/', // Base URL for your project */


### PR DESCRIPTION
fixes 1366: Docusaurus appends the title with url. In absence of
title 'undefined' was shown.

Signed-off-by: Jayesh Kumar <k8scncf@gmail.com>

The page has now the attached view. Please let know if this will be fine?
![litmusdocs](https://user-images.githubusercontent.com/57744184/77563689-9d132600-6ee7-11ea-863e-c435ddefe6ff.png)
