### PR TITLE
Fix56: Add Scroll to Top button for documentation

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -122,7 +122,14 @@ const siteConfig = {
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo's URL...
   repoUrl: 'https://github.com/litmuschaos/litmus',
-  twitterUsername: 'LitmusChaos'
+  twitterUsername: 'LitmusChaos',
+
+  scrollToTop: true,
+  scrollToTopOptions: {
+    scrollDuration: 200,
+    diameter: 35,
+    backgroundColor: 'gray',
+  },
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
Added logic for scroll to top button for Litmus Docs.
Fixes: https://github.com/litmuschaos/litmus-docs/issues/56

Signed-off-by: Jayesh Kumar <k8scncf@gmail.com>