### PR TITLE
core(update): update newly added environment variables in node-cpu-hog docs and embedmd run

### DIFF
--- a/docs/container-kill.md
+++ b/docs/container-kill.md
@@ -127,6 +127,18 @@ subjects:
     <td> If the TARGET_CONTAINER is not provided it will delete the first container </td>
   </tr>
   <tr>
+    <td> CHAOS_INTERVAL  </td>
+    <td> Time interval b/w two successive container kill (in sec) </td>
+    <td> Optional </td>
+    <td> If the CHAOS_INTERVAL is not provided it will take the default value of 10s </td>
+  </tr>
+  <tr>
+    <td> TOTAL_CHAOS_DURATION  </td>
+    <td> The time duration for chaos injection (seconds) </td>
+    <td> Optional </td>
+    <td> Defaults to 20s </td>
+  </tr>    
+  <tr>
     <td> LIB_IMAGE  </td>
     <td> The pumba/containerd image used to run the kill command </td>
     <td> Optional </td>
@@ -184,6 +196,14 @@ spec:
             # specify the name of the container to be killed
             - name: TARGET_CONTAINER
               value: 'nginx'
+
+            # provide the chaos interval
+            - name: CHAOS_INTERVAL
+              value: '10'
+
+            # provide the total chaos duration
+            - name: TOTAL_CHAOS_DURATION
+              value: '20'
 ```
 
 ### Create the ChaosEngine Resource

--- a/docs/node-cpu-hog.md
+++ b/docs/node-cpu-hog.md
@@ -133,6 +133,13 @@ subjects:
     <td> </td>
   </tr>
   <tr>
+    <td> NODE_CPU_CORE </td>
+    <td> Number of cores of node CPU to be consumed  </td>
+    <td> Defaults to `2` </td>
+    <td> Optional  </td>
+    <td> </td>
+  </tr>  
+  <tr>
     <td> INSTANCE_ID </td>
     <td> A user-defined string that holds metadata/info about current run/instance of chaos. Ex: 04-05-2020-9-00. This string is appended as suffix in the chaosresult CR name.</td>
     <td> Optional </td>

--- a/docs/pod-network-corruption.md
+++ b/docs/pod-network-corruption.md
@@ -170,7 +170,7 @@ subjects:
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
-  name:  nginx-network-chaos
+  name: nginx-network-chaos
   namespace: default
 spec:
   # It can be delete/retain

--- a/docs/pod-network-latency.md
+++ b/docs/pod-network-latency.md
@@ -171,7 +171,7 @@ subjects:
 apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
-  name:  nginx-network-chaos
+  name: nginx-network-chaos
   namespace: default
 spec: 
   # It can be delete/retain


### PR DESCRIPTION
**Why do we need this?**

- This PR is for adding the `NODE_CPU_CORE` variable in the docs section of the node-cpu-hog experiment. A feature was added in litmus `1.3` - that a custom cpu cores can also be provided to run the node cpu hog chaos but this parameter was missing in the docs section. 
- It also contains the embedmd run output.

issue - https://github.com/litmuschaos/litmus/issues/1498
Signed-off-by: Udit Gaurav <uditgaurav@gmail.com>