### PR TITLE
add AKS as Tested Platform

### DIFF
--- a/docs/container-kill.md
+++ b/docs/container-kill.md
@@ -16,7 +16,7 @@ sidebar_label: Container Kill
   <tr>
     <td> Generic </td>
     <td> Kill one container in the application pod </td>
-    <td> GKE, Packet(Kubeadm), Minikube, EKS </td>
+    <td> GKE, Packet(Kubeadm), Minikube, EKS, AKS </td>
   </tr>
 </table>
 

--- a/docs/disk-fill.md
+++ b/docs/disk-fill.md
@@ -16,7 +16,7 @@ sidebar_label: Disk Fill
   <tr>
     <td> Chaos </td>
     <td> Fill up Ephemeral Storage of a Pod </td>
-    <td> GKE, EKS </td>
+    <td> GKE, EKS, AKS </td>
   </tr>
 </table>
 

--- a/docs/docker-service-kill.md
+++ b/docs/docker-service-kill.md
@@ -16,7 +16,7 @@ sidebar_label: Docker Service Kill
   <tr>
     <td> Generic </td>
     <td> Kills the docker service on the application node to check the resiliency. </td>
-    <td> GKE </td>
+    <td> GKE, AKS </td>
   </tr>
 </table>
 

--- a/docs/kubelet-service-kill.md
+++ b/docs/kubelet-service-kill.md
@@ -16,7 +16,7 @@ sidebar_label: Kubelet Service Kill
   <tr>
     <td> Generic </td>
     <td> Kills the kubelet service on the application node to check the resiliency. </td>
-    <td> GKE, EKS, Packet(Kubeadm) </td>
+    <td> GKE, EKS, Packet(Kubeadm), AKS </td>
   </tr>
 </table>
 

--- a/docs/node-cpu-hog.md
+++ b/docs/node-cpu-hog.md
@@ -16,7 +16,7 @@ sidebar_label: Node CPU Hog
   <tr>
     <td> Generic </td>
     <td> Exhaust CPU resources on the Kubernetes Node </td>
-    <td> GKE, EKS </td>
+    <td> GKE, EKS, AKS </td>
   </tr>
 </table>
 

--- a/docs/node-drain.md
+++ b/docs/node-drain.md
@@ -16,7 +16,7 @@ sidebar_label: Node Drain
   <tr>
     <td> Generic </td>
     <td> Drain the node where application pod is scheduled. </td>
-    <td> GKE, AWS, Packet(Kubeadm), Konvoy(AWS), EKS </td>
+    <td> GKE, AWS, Packet(Kubeadm), Konvoy(AWS), EKS, AKS </td>
   </tr>
 </table>
 

--- a/docs/node-memory-hog.md
+++ b/docs/node-memory-hog.md
@@ -16,7 +16,7 @@ sidebar_label: Node Memory Hog
   <tr>
     <td> Generic </td>
     <td> Exhaust Memory resources on the Kubernetes Node </td>
-    <td> GKE, EKS </td>
+    <td> GKE, EKS, AKS </td>
   </tr>
 </table>
 

--- a/docs/node-taint.md
+++ b/docs/node-taint.md
@@ -16,7 +16,7 @@ sidebar_label: Node Taint
   <tr>
     <td> Generic </td>
     <td> Taint the node where application pod is scheduled. </td>
-    <td> GKE, AWS, Packet(Kubeadm), Konvoy(AWS), EKS </td>
+    <td> GKE, AWS, Packet(Kubeadm), Konvoy(AWS), EKS, AKS </td>
   </tr>
 </table>
 

--- a/docs/pod-cpu-hog.md
+++ b/docs/pod-cpu-hog.md
@@ -16,7 +16,7 @@ sidebar_label: Pod CPU Hog
   <tr>
      <td> Generic </td>
     <td> Consume CPU resources on the application container</td>
-    <td> GKE, Packet(Kubeadm), Minikube, EKS  </td>
+    <td> GKE, Packet(Kubeadm), Minikube, EKS, AKS  </td>
   </tr>
 </table>
 

--- a/docs/pod-delete.md
+++ b/docs/pod-delete.md
@@ -16,7 +16,7 @@ sidebar_label: Pod Delete
   <tr>
     <td> Generic </td>
     <td> Fail the application pod </td>
-    <td> GKE, Konvoy(AWS), Packet(Kubeadm), Minikube, EKS </td>
+    <td> GKE, Konvoy(AWS), Packet(Kubeadm), Minikube, EKS, AKS </td>
   </tr>
 </table>
 

--- a/docs/pod-memory-hog.md
+++ b/docs/pod-memory-hog.md
@@ -16,7 +16,7 @@ sidebar_label: Pod Memory Hog
   <tr>
      <td> Generic </td>
     <td> Consume memory resources on the application container</td>
-    <td> GKE, Packet(Kubeadm), Minikube, EKS  </td>
+    <td> GKE, Packet(Kubeadm), Minikube, EKS, AKS  </td>
   </tr>
 </table>
 

--- a/docs/pod-network-corruption.md
+++ b/docs/pod-network-corruption.md
@@ -16,7 +16,7 @@ sidebar_label: Pod Network Corruption
   <tr>
     <td> Generic </td>
     <td> Inject Network Packet Corruption Into Application Pod </td>
-    <td> GKE, Packet(Kubeadm), EKS, Minikube > v1.6.0 </td>
+    <td> GKE, Packet(Kubeadm), EKS, Minikube > v1.6.0, AKS </td>
   </tr>
 </table>
 

--- a/docs/pod-network-duplication.md
+++ b/docs/pod-network-duplication.md
@@ -16,7 +16,7 @@ sidebar_label: Pod Network Duplication
   <tr>
     <td> Generic </td>
     <td> Inject Packet Duplication Into Application Pod </td>
-    <td> GKE, Packet(Kubeadm), EKS, Minikube > v1.6.0 </td>
+    <td> GKE, Packet(Kubeadm), EKS, Minikube > v1.6.0, AKS </td>
   </tr>
 </table>
 

--- a/docs/pod-network-latency.md
+++ b/docs/pod-network-latency.md
@@ -16,7 +16,7 @@ sidebar_label: Pod Network Latency
   <tr>
     <td> Generic </td>
     <td> Inject Network Latency Into Application Pod </td>
-    <td> GKE, Packet(Kubeadm), EKS, Minikube > v1.6.0 </td>
+    <td> GKE, Packet(Kubeadm), EKS, Minikube > v1.6.0, AKS </td>
   </tr>
 </table>
 

--- a/docs/pod-network-loss.md
+++ b/docs/pod-network-loss.md
@@ -16,7 +16,7 @@ sidebar_label: Pod Network Loss
   <tr>
     <td> Generic </td>
     <td> Inject Packet Loss Into Application Pod </td>
-    <td> GKE, Packet(Kubeadm), EKS, Minikube > v1.6.0 </td>
+    <td> GKE, Packet(Kubeadm), EKS, Minikube > v1.6.0, AKS </td>
   </tr>
 </table>
 


### PR DESCRIPTION
Signed-off-by: ToruMakabe <tomakabe@microsoft.com>

Tested almost all generic experiments on AKS.

* AKS k8s version: 1.18.4
* Litmus Chaos version: 1.6.0
* Test results: [here](https://gist.github.com/ToruMakabe/ce6df0f40b8327091e0074c189c94bb4)