### PR TITLE
(chore): Add actions for pushing auto embedmd if not done in the PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: LitmusDocs-CI
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  embedmd:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{steps.getcommit.outputs.sha}}
+
+      - uses: actions/setup-go@v2
+        with:
+          stable: 'false'
+          go-version: '1.14.0'
+
+      - name: Installing and Running embedmed
+        run: |
+          go get github.com/campoy/embedmd
+          cd docs
+          embedmd -w $(find *.md)
+        continue-on-error: true  
+
+      - name: Commit files
+        run: |
+          git config --local user.email "litmuschaosbot@github.com"
+          git config --local user.name "LitmusChaos"
+          git commit -s -m "Add embedmd changes" -a
+        continue-on-error: true
+        
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,15 @@ Litmus documentation currently runs using [Docusaurus](https://docusaurus.io/) s
 
 A sample PR flow is outlined [here](https://guides.github.com/introduction/flow/). More detailed one is [here](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
 
+## Use embedmd command before commiting changes
+
+- Once you're done with the changes don't forget to run `embedmd` which will extract the embedded code from different files. For this you need do:
+
+```bash
+cd docs
+embedmd -w $(find *.md)
+```
+
 ## Pull Request Checklist
 
 * Rebase to the current master branch before submitting your pull request.

--- a/README.md
+++ b/README.md
@@ -19,11 +19,25 @@ The website server can be setup manually or through docker and docker compose
 
 The embedded code will be extracted from the file at `URL`, which can either be a relative path to a file in the local file system (using always forward slashes as directory separator) or a URL starting with `http://` or `https://.`
 
- Flags (needs to be done before commiting the changes): 
+_Installation:_
 
--w: Executing `embedmd -w docs.md` will modify docs.md and add the corresponding code snippets, as shown in sample/result.md.
+- We can install embedmd with golang, make sure we have [golang](https://github.com/golang/go) installed in our system. We just need to run the following command to install embedmd.
 
--d: Executing `embedmd -d docs.md` will display the difference between the contents of docs.md and the output of embedmd docs.md.
+```bash
+go get github.com/campoy/embedmd
+```
+
+_Run embedmd (needs to be done before commiting the changes):_
+
+- Follow the steps (from root directory) to run embedmd:
+
+```bash
+cd docs
+embedmd -w $(find *.md)
+```
+_Check the difference:_
+
+- Executing `embedmd -d docs-name.md` will display the difference between the contents of docs-name.md and the output of embedmd docs-name.md.
 
 
 ## Manual Setup

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ git clone https://github.com/litmuschaos/litmus-docs.git
 cd litmus-docs
 ```
 
-The website server can be setup manually or through docker and docker compose
+The docs website server can be setup manually or through docker compose
 
 ## Use embedmd command before commiting changes
 
-The embedded code will be extracted from the file at `URL`, which can either be a relative path to a file in the local file system (using always forward slashes as directory separator) or a URL starting with `http://` or `https://.`
+The embedded code will be extracted from the file at `URL`, which can either be a relative path to a file in the local file system (using forward slashes as directory separator) or a URL starting with `http://` or `https://.`
 
 _Installation:_
 
-- We can install embedmd with golang, make sure we have [golang](https://github.com/golang/go) installed in our system. We just need to run the following command to install embedmd.
+- Make sure you have [golang](https://github.com/golang/go) installed. We just need to run the following command to install embedmd.
 
 ```bash
 go get github.com/campoy/embedmd


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

## Details

This PR is for:

- Add GitHub Actions for adding `embedmd`(_embedmd is no more mandatory_): If we miss running the embedmd command on any PR or if someone is unable to run embedmd we can merge the PR without `embedmd` and the Github actions will check for every merge (push) that the code is embedded or not, if not then it do a fresh commit with the embedded code.

- Adding steps for running embedmd in README.md and contributor guide.



