### PR TITLE
Add doc for runner's configMap & secret

### DIFF
--- a/docs/chaosengine-concepts.md
+++ b/docs/chaosengine-concepts.md
@@ -453,7 +453,7 @@ This section describes the fields in the ChaosEngine spec and the possible value
 </tr>
 <tr>
   <th>Notes</th>
-  <td>The <code>.spec.components.runner.configMaps</code> provides for a means to insert config information into the runner pod. The configmaps definition is validated for correctness and those specified are checked for availability (in the cluster/namespace) before being mounted into the runner pod.</td>
+  <td>The <code>.spec.components.runner.configMaps</code> provides for a means to insert config information into the runner pod.</td>
 </tr>
 </table>
 
@@ -480,7 +480,7 @@ This section describes the fields in the ChaosEngine spec and the possible value
 </tr>
 <tr>
   <th>Notes</th>
-  <td>The <code>.spec.components.runner.secrets</code> provides for a means to push secrets (typically project ids, access credentials etc.,) into the chaos runner pod. These are especially useful in case of platform-level/infra-level chaos experiments. The secrets definition is validated for correctness and those specified are checked for availability (in the cluster/namespace) before being mounted into the chaos runner pod.</td>
+  <td>The <code>.spec.components.runner.secrets</code> provides for a means to push secrets (typically project ids, access credentials etc.,) into the chaos runner pod. These are especially useful in case of platform-level/infra-level chaos experiments. </td>
 </tr>
 </table>
 

--- a/docs/chaosengine-concepts.md
+++ b/docs/chaosengine-concepts.md
@@ -430,6 +430,60 @@ This section describes the fields in the ChaosEngine spec and the possible value
 </tr>
 </table>
 
+<table>
+<tr>
+  <th>Field</th>
+  <td><code>.spec.components.runner.configMaps</code></td>
+</tr>
+<tr>
+  <th>Description</th>
+  <td>Configmaps passed to the chaos runner pod</td>
+</tr>
+<tr>
+  <th>Type</th>
+  <td>Optional</td>
+</tr>
+<tr>
+  <th>Range</th>
+<td><i>user-defined</i> (type: {name: string, mountPath: string})</td>
+</tr>
+<tr>
+  <th>Default</th>
+  <td><i>n/a</i></td>
+</tr>
+<tr>
+  <th>Notes</th>
+  <td>The <code>.spec.components.runner.configMaps</code> provides for a means to insert config information into the runner pod. The configmaps definition is validated for correctness and those specified are checked for availability (in the cluster/namespace) before being mounted into the runner pod.</td>
+</tr>
+</table>
+
+<table>
+<tr>
+  <th>Field</th>
+  <td><code>.spec.components.runner.secrets</code></td>
+</tr>
+<tr>
+  <th>Description</th>
+  <td>Kubernetes secrets passed to the chaos runner pod.</td>
+</tr>
+<tr>
+  <th>Type</th>
+  <td>Optional</td>
+</tr>
+<tr>
+  <th>Range</th>
+<td><i>user-defined</i> (type: {name: string, mountPath: string})</td>
+</tr>
+<tr>
+  <th>Default</th>
+  <td><i>n/a</i></td>
+</tr>
+<tr>
+  <th>Notes</th>
+  <td>The <code>.spec.components.runner.secrets</code> provides for a means to push secrets (typically project ids, access credentials etc.,) into the chaos runner pod. These are especially useful in case of platform-level/infra-level chaos experiments. The secrets definition is validated for correctness and those specified are checked for availability (in the cluster/namespace) before being mounted into the chaos runner pod.</td>
+</tr>
+</table>
+
 ## Experiment Specification
 
 <table>


### PR DESCRIPTION
Signed-off-by: Ondra Machacek <omachace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This PR updates documentation as per: https://github.com/litmuschaos/chaos-operator/pull/284

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
