### PR TITLE
Add AKS as tested platform to new experiments

### DIFF
--- a/docs/node-io-stress.md
+++ b/docs/node-io-stress.md
@@ -16,7 +16,7 @@ sidebar_label: Node IO Stress
   <tr>
     <td> Generic </td>
     <td> Give IO Disk Stress on the Kubernetes Node </td>
-    <td> GKE, EKS, Minikube, AKS </td>
+    <td> GKE, EKS, Minikube </td>
   </tr>
 </table>
 
@@ -139,13 +139,13 @@ subjects:
     <td> It is the number of IO workers involved in IO disk stress </td>
     <td> Optional  </td>
     <td> Default to 4 </td>
-  </tr>
+  </tr>   
   <tr>
     <td> APP_NODE </td>
     <td> Name of the node subjected to IO stress </td>
     <td> Optional  </td>
     <td> If not provided. It will select the app node from appinfo randomly</td>
-  </tr>
+  </tr>  
    <tr>
     <td> LIB  </td>
     <td> The chaos lib used to inject the chaos </td>
@@ -187,7 +187,7 @@ spec:
   annotationCheck: 'false'
   # It can be active/stop
   engineState: 'active'
-  #ex. values: ns1:name=percona,ns2:run=nginx
+  #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   appinfo:
     appns: 'default'
@@ -209,7 +209,7 @@ spec:
             ## specify the size as percentage of free space on the file system
             - name: FILESYSTEM_UTILIZATION_PERCENTAGE
               value: '10'
-
+            
              ## enter the name of the desired node
             - name: APP_NODE
               value: ''
@@ -221,19 +221,19 @@ spec:
 
   `kubectl apply -f chaosengine.yml`
 
-- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/)
+- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/) 
   section to identify the root cause and fix the issues.
 
 ### Watch Chaos progress
 
-- View the status of the pods as they are subjected to IO disk stress.
+- View the status of the pods as they are subjected to IO disk stress. 
 
   `watch -n 1 kubectl get pods -n <application-namespace>`
 
 - Monitor the capacity filled up on the host filesystem
 
   `watch du -h`
-
+  
 ### Abort/Restart the Chaos Experiment
 
 - To stop the pod-io-stress experiment immediately, either delete the ChaosEngine resource or execute the following command:

--- a/docs/node-io-stress.md
+++ b/docs/node-io-stress.md
@@ -16,7 +16,7 @@ sidebar_label: Node IO Stress
   <tr>
     <td> Generic </td>
     <td> Give IO Disk Stress on the Kubernetes Node </td>
-    <td> GKE, EKS, Minikube </td>
+    <td> GKE, EKS, Minikube, AKS </td>
   </tr>
 </table>
 
@@ -139,13 +139,13 @@ subjects:
     <td> It is the number of IO workers involved in IO disk stress </td>
     <td> Optional  </td>
     <td> Default to 4 </td>
-  </tr>   
+  </tr>
   <tr>
     <td> APP_NODE </td>
     <td> Name of the node subjected to IO stress </td>
     <td> Optional  </td>
     <td> If not provided. It will select the app node from appinfo randomly</td>
-  </tr>  
+  </tr>
    <tr>
     <td> LIB  </td>
     <td> The chaos lib used to inject the chaos </td>
@@ -187,7 +187,7 @@ spec:
   annotationCheck: 'false'
   # It can be active/stop
   engineState: 'active'
-  #ex. values: ns1:name=percona,ns2:run=nginx 
+  #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   appinfo:
     appns: 'default'
@@ -209,7 +209,7 @@ spec:
             ## specify the size as percentage of free space on the file system
             - name: FILESYSTEM_UTILIZATION_PERCENTAGE
               value: '10'
-            
+
              ## enter the name of the desired node
             - name: APP_NODE
               value: ''
@@ -221,19 +221,19 @@ spec:
 
   `kubectl apply -f chaosengine.yml`
 
-- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/) 
+- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/)
   section to identify the root cause and fix the issues.
 
 ### Watch Chaos progress
 
-- View the status of the pods as they are subjected to IO disk stress. 
+- View the status of the pods as they are subjected to IO disk stress.
 
   `watch -n 1 kubectl get pods -n <application-namespace>`
 
 - Monitor the capacity filled up on the host filesystem
 
   `watch du -h`
-  
+
 ### Abort/Restart the Chaos Experiment
 
 - To stop the pod-io-stress experiment immediately, either delete the ChaosEngine resource or execute the following command:

--- a/docs/node-io-stress.md
+++ b/docs/node-io-stress.md
@@ -16,7 +16,7 @@ sidebar_label: Node IO Stress
   <tr>
     <td> Generic </td>
     <td> Give IO Disk Stress on the Kubernetes Node </td>
-    <td> GKE, EKS, Minikube </td>
+    <td> GKE, EKS, Minikube, AKS </td>
   </tr>
 </table>
 

--- a/docs/pod-autoscaler.md
+++ b/docs/pod-autoscaler.md
@@ -16,7 +16,7 @@ sidebar_label: Pod Autoscaler
   <tr>
     <td> Generic </td>
     <td> Scale the application replicas and test the node autoscaling on cluster </td>
-    <td> GKE, EKS, Minikube </td>
+    <td> GKE, EKS, Minikube, AKS </td>
   </tr>
 </table>
 
@@ -42,7 +42,7 @@ sidebar_label: Pod Autoscaler
 ## Integrations
 
 - Pod Autoscaler can be effected using the chaos library: `litmus`
-- The desired chaos library can be selected by setting `litmus` as value for the env variable `LIB` 
+- The desired chaos library can be selected by setting `litmus` as value for the env variable `LIB`
 
 ## Steps to Execute the Chaos Experiment
 
@@ -162,7 +162,7 @@ spec:
   annotationCheck: 'false'
   # It can be active/stop
   engineState: 'active'
-  #ex. values: ns1:name=percona,ns2:run=nginx 
+  #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   appinfo:
     appns: 'default'
@@ -184,7 +184,7 @@ spec:
             # number of replicas to scale
             - name: REPLICA_COUNT
               value: '5'
-              
+
 ```
 
 ### Create the ChaosEngine Resource
@@ -193,7 +193,7 @@ spec:
 
   `kubectl apply -f chaosengine.yml`
 
-- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/) 
+- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/)
   section to identify the root cause and fix the issues.
 
 ### Watch Chaos progress

--- a/docs/pod-autoscaler.md
+++ b/docs/pod-autoscaler.md
@@ -16,7 +16,7 @@ sidebar_label: Pod Autoscaler
   <tr>
     <td> Generic </td>
     <td> Scale the application replicas and test the node autoscaling on cluster </td>
-    <td> GKE, EKS, Minikube, AKS </td>
+    <td> GKE, EKS, Minikube </td>
   </tr>
 </table>
 
@@ -42,7 +42,7 @@ sidebar_label: Pod Autoscaler
 ## Integrations
 
 - Pod Autoscaler can be effected using the chaos library: `litmus`
-- The desired chaos library can be selected by setting `litmus` as value for the env variable `LIB`
+- The desired chaos library can be selected by setting `litmus` as value for the env variable `LIB` 
 
 ## Steps to Execute the Chaos Experiment
 
@@ -162,7 +162,7 @@ spec:
   annotationCheck: 'false'
   # It can be active/stop
   engineState: 'active'
-  #ex. values: ns1:name=percona,ns2:run=nginx
+  #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   appinfo:
     appns: 'default'
@@ -184,7 +184,7 @@ spec:
             # number of replicas to scale
             - name: REPLICA_COUNT
               value: '5'
-
+              
 ```
 
 ### Create the ChaosEngine Resource
@@ -193,7 +193,7 @@ spec:
 
   `kubectl apply -f chaosengine.yml`
 
-- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/)
+- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/) 
   section to identify the root cause and fix the issues.
 
 ### Watch Chaos progress

--- a/docs/pod-autoscaler.md
+++ b/docs/pod-autoscaler.md
@@ -16,7 +16,7 @@ sidebar_label: Pod Autoscaler
   <tr>
     <td> Generic </td>
     <td> Scale the application replicas and test the node autoscaling on cluster </td>
-    <td> GKE, EKS, Minikube </td>
+    <td> GKE, EKS, Minikube, AKS </td>
   </tr>
 </table>
 

--- a/docs/pod-io-stress.md
+++ b/docs/pod-io-stress.md
@@ -16,7 +16,7 @@ sidebar_label: Pod IO Stress
   <tr>
      <td> Generic </td>
     <td> Inject IO stress on the application container</td>
-    <td> GKE, Packet(Kubeadm), Minikube </td>
+    <td> GKE, Packet(Kubeadm), Minikube, AKS </td>
   </tr>
 </table>
 
@@ -130,13 +130,13 @@ subjects:
     <td> It is the number of IO workers involved in IO disk stress </td>
     <td> Optional  </td>
     <td> Default to 4 </td>
-  </tr> 
+  </tr>
   <tr>
     <td> TARGET_POD </td>
     <td> Name of the application pod subjected to IO stress chaos</td>
     <td> Optional </td>
     <td> If not provided it will select from the appLabel provided</td>
-  </tr>   
+  </tr>
   <tr>
     <td> TOTAL_CHAOS_DURATION </td>
     <td> The time duration for chaos (seconds)  </td>
@@ -154,19 +154,19 @@ subjects:
     <td> Image used to run the stress command </td>
     <td> Optional  </td>
     <td> Default to <code>gaiaadm/pumba<code> </td>
-  </tr>  
+  </tr>
   <tr>
     <td> TARGET_POD </td>
     <td> Name of the application pod subjected to pod io stress chaos<td>
     <td> Optional </td>
     <td> If not provided it will select from the appLabel provided</td>
-  </tr>  
+  </tr>
   <tr>
     <td> PODS_AFFECTED_PERC </td>
     <td> The Percentage of total pods to target  </td>
     <td> Optional </td>
     <td> Default to 0% (corresponds to 1 replica) </td>
-  </tr> 
+  </tr>
   <tr>
     <td> RAMP_TIME </td>
     <td> Period to wait before and after injection of chaos in sec </td>
@@ -202,7 +202,7 @@ spec:
   annotationCheck: 'true'
   # It can be active/stop
   engineState: 'active'
-  #ex. values: ns1:name=percona,ns2:run=nginx 
+  #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   appinfo:
     appns: 'default'
@@ -235,12 +235,12 @@ spec:
 
   `kubectl apply -f chaosengine.yml`
 
-- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/) 
+- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/)
   section to identify the root cause and fix the issues.
 
 ### Watch Chaos progress
 
-- View the status of the pods as they are subjected to IO disk stress. 
+- View the status of the pods as they are subjected to IO disk stress.
 
   `watch -n 1 kubectl get pods -n <application-namespace>`
 
@@ -250,13 +250,13 @@ spec:
 
 ### Abort/Restart the Chaos Experiment
 
-- To stop the pod-io-stress experiment immediately, either delete the ChaosEngine resource or execute the following command: 
+- To stop the pod-io-stress experiment immediately, either delete the ChaosEngine resource or execute the following command:
 
-  `kubectl patch chaosengine <chaosengine-name> -n <namespace> --type merge --patch '{"spec":{"engineState":"stop"}}'` 
+  `kubectl patch chaosengine <chaosengine-name> -n <namespace> --type merge --patch '{"spec":{"engineState":"stop"}}'`
 
-- To restart the experiment, either re-apply the ChaosEngine YAML or execute the following command: 
+- To restart the experiment, either re-apply the ChaosEngine YAML or execute the following command:
 
-  `kubectl patch chaosengine <chaosengine-name> -n <namespace> --type merge --patch '{"spec":{"engineState":"active"}'`  
+  `kubectl patch chaosengine <chaosengine-name> -n <namespace> --type merge --patch '{"spec":{"engineState":"active"}'`
 
 
 ### Check Chaos Experiment Result

--- a/docs/pod-io-stress.md
+++ b/docs/pod-io-stress.md
@@ -16,7 +16,7 @@ sidebar_label: Pod IO Stress
   <tr>
      <td> Generic </td>
     <td> Inject IO stress on the application container</td>
-    <td> GKE, Packet(Kubeadm), Minikube </td>
+    <td> GKE, Packet(Kubeadm), Minikube, AKS </td>
   </tr>
 </table>
 

--- a/docs/pod-io-stress.md
+++ b/docs/pod-io-stress.md
@@ -16,7 +16,7 @@ sidebar_label: Pod IO Stress
   <tr>
      <td> Generic </td>
     <td> Inject IO stress on the application container</td>
-    <td> GKE, Packet(Kubeadm), Minikube, AKS </td>
+    <td> GKE, Packet(Kubeadm), Minikube </td>
   </tr>
 </table>
 
@@ -130,13 +130,13 @@ subjects:
     <td> It is the number of IO workers involved in IO disk stress </td>
     <td> Optional  </td>
     <td> Default to 4 </td>
-  </tr>
+  </tr> 
   <tr>
     <td> TARGET_POD </td>
     <td> Name of the application pod subjected to IO stress chaos</td>
     <td> Optional </td>
     <td> If not provided it will select from the appLabel provided</td>
-  </tr>
+  </tr>   
   <tr>
     <td> TOTAL_CHAOS_DURATION </td>
     <td> The time duration for chaos (seconds)  </td>
@@ -154,19 +154,19 @@ subjects:
     <td> Image used to run the stress command </td>
     <td> Optional  </td>
     <td> Default to <code>gaiaadm/pumba<code> </td>
-  </tr>
+  </tr>  
   <tr>
     <td> TARGET_POD </td>
     <td> Name of the application pod subjected to pod io stress chaos<td>
     <td> Optional </td>
     <td> If not provided it will select from the appLabel provided</td>
-  </tr>
+  </tr>  
   <tr>
     <td> PODS_AFFECTED_PERC </td>
     <td> The Percentage of total pods to target  </td>
     <td> Optional </td>
     <td> Default to 0% (corresponds to 1 replica) </td>
-  </tr>
+  </tr> 
   <tr>
     <td> RAMP_TIME </td>
     <td> Period to wait before and after injection of chaos in sec </td>
@@ -202,7 +202,7 @@ spec:
   annotationCheck: 'true'
   # It can be active/stop
   engineState: 'active'
-  #ex. values: ns1:name=percona,ns2:run=nginx
+  #ex. values: ns1:name=percona,ns2:run=nginx 
   auxiliaryAppInfo: ''
   appinfo:
     appns: 'default'
@@ -235,12 +235,12 @@ spec:
 
   `kubectl apply -f chaosengine.yml`
 
-- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/)
+- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/) 
   section to identify the root cause and fix the issues.
 
 ### Watch Chaos progress
 
-- View the status of the pods as they are subjected to IO disk stress.
+- View the status of the pods as they are subjected to IO disk stress. 
 
   `watch -n 1 kubectl get pods -n <application-namespace>`
 
@@ -250,13 +250,13 @@ spec:
 
 ### Abort/Restart the Chaos Experiment
 
-- To stop the pod-io-stress experiment immediately, either delete the ChaosEngine resource or execute the following command:
+- To stop the pod-io-stress experiment immediately, either delete the ChaosEngine resource or execute the following command: 
 
-  `kubectl patch chaosengine <chaosengine-name> -n <namespace> --type merge --patch '{"spec":{"engineState":"stop"}}'`
+  `kubectl patch chaosengine <chaosengine-name> -n <namespace> --type merge --patch '{"spec":{"engineState":"stop"}}'` 
 
-- To restart the experiment, either re-apply the ChaosEngine YAML or execute the following command:
+- To restart the experiment, either re-apply the ChaosEngine YAML or execute the following command: 
 
-  `kubectl patch chaosengine <chaosengine-name> -n <namespace> --type merge --patch '{"spec":{"engineState":"active"}'`
+  `kubectl patch chaosengine <chaosengine-name> -n <namespace> --type merge --patch '{"spec":{"engineState":"active"}'`  
 
 
 ### Check Chaos Experiment Result


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Add AKS as a tested platform to 3 new experiments (pod-autoscaler, pod-io-stress, node-io-stress)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes litmuschaos/litmus#2275

**Special notes for your reviewer**:

* AKS 1.18.8
* Litmus 1.9.0
* Test results iare [here](https://gist.github.com/ToruMakabe/d3bfe357a02eb6650af53e6e189094ac)

**Checklist:**
-   [x] Fixes litmuschaos/litmus#2275
-   [x] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
