### PR TITLE
Remove probePollingInterval from Edge mode example

### DIFF
--- a/docs/litmus-probe.md
+++ b/docs/litmus-probe.md
@@ -72,7 +72,6 @@ probe:
     probeTimeout: 5
     interval: 5
     retry: 1
-    probePollingInterval: 2
 
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
The PR updates the 'Edge' mode probe example by removing `probePollingInterval` attribute which is supported only by 'continuous' mode

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Signed the commit for DCO to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag

Signed-off-by: Moti Asayag <masayag@redhat.com>