### PR TITLE
chore(new_exp): Add docs for ebs loss and ec2 terminate experiments

### DIFF
--- a/docs/chaostoolkit-aws-ec2-terminate.md
+++ b/docs/chaostoolkit-aws-ec2-terminate.md
@@ -1,7 +1,7 @@
 ---
 id: Kubernetes-Chaostoolkit-AWS
 title: ChaosToolKit AWS EC2 Experiment Details
-sidebar_label: EC2 Terminate 
+sidebar_label: ChaosToolKit AWS EC2 Terminate 
 ---
 ------
 

--- a/docs/ebs-loss.md
+++ b/docs/ebs-loss.md
@@ -1,0 +1,244 @@
+---
+id: ebs-loss
+title: EBS Loss Experiment Details
+sidebar_label: EBS Loss
+---
+------
+
+## Experiment Metadata
+
+<table>
+  <tr>
+    <th> Type </th>
+    <th>  Description  </th>
+    <th> Tested K8s Platform </th>
+  </tr>
+  <tr>
+    <td> Kube AWS </td>
+    <td> EBS volume loss against specified application </td>
+    <td> EKS </td>
+  </tr>
+</table>
+
+## Prerequisites
+
+- Ensure that Kubernetes Version > 1.13
+- Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
+- Ensure that the `ebs-loss` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace If not, install from [here](https://hub.litmuschaos.io/api/chaos/1.9.1?file=charts/kube-aws/ebs-loss/experiment.yaml)
+- Ensure that you have sufficient AWS access to attach or detach an ebs volume from the instance.
+- Ensure to create a Kubernetes secret having the AWS access configuration(key) in the `CHAOS_NAMESPACE`. A sample secret file looks like:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-secret
+type: Opaque
+stringData:
+  cloud_config.yml: |-
+  # Add the cloud AWS credentials respectively
+  [default]
+  aws_access_key_id = XXXXXXXXXXXXXXXXXXX
+  aws_secret_access_key = XXXXXXXXXXXXXXX
+```
+
+## Entry-Criteria
+
+-   Application pods are healthy before chaos injection also ebs volume is attached to the instance.
+
+## Exit-Criteria
+
+-   Application pods are healthy post chaos injection and ebs volume is attached to the instance.
+
+## Details
+
+-   Causes chaos to disrupt state of infra resources ebs volume loss from node or ec2 instance for a certain chaos duration.
+-   Causes Pod to get Evicted if the Pod exceeds it Ephemeral Storage Limit.
+-   Tests deployment sanity (replica availability & uninterrupted service) and recovery workflows of the application pod
+
+## Integrations
+
+-   EBS Loss can be effected using the chaos library: `litmus`, which makes use of aws sdk to attach/detach an ebs volume from the target instance. 
+    specified capacity on the node.
+-   The desired chaoslib can be selected by setting the above options as value for the env variable `LIB`
+
+## Steps to Execute the Chaos Experiment
+
+- This Chaos Experiment can be triggered by creating a ChaosEngine resource on the cluster. To understand the values to provide in a ChaosEngine specification, refer [Getting Started](getstarted.md/#prepare-chaosengine)
+
+- Follow the steps in the sections below to create the chaosServiceAccount, prepare the ChaosEngine & execute the experiment.
+
+### Prepare chaosServiceAccount
+
+- Use this sample RBAC manifest to create a chaosServiceAccount in the desired (app) namespace. This example consists of the minimum necessary role permissions to execute the experiment.
+
+#### Sample Rbac Manifest
+
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kube-aws/ebs-loss/rbac.yaml yaml)
+```yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ebs-loss-sa
+  namespace: default
+  labels:
+    name: ebs-loss-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ebs-loss-sa
+  labels:
+    name: ebs-loss-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+- apiGroups: ["","litmuschaos.io","batch"]
+  resources: ["pods","jobs","secrets","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ebs-loss-sa
+  labels:
+    name: ebs-loss-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ebs-loss-sa
+subjects:
+- kind: ServiceAccount
+  name: ebs-loss-sa
+  namespace: default
+```
+
+### Prepare ChaosEngine
+
+- Provide the application info in `spec.appinfo`
+- Provide the auxiliary applications info (ns & labels) in `spec.auxiliaryAppInfo`
+- Override the experiment tunables if desired in `experiments.spec.components.env`
+- To understand the values to provided in a ChaosEngine specification, refer [ChaosEngine Concepts](chaosengine-concepts.md)
+
+#### Supported Experiment Tunables
+
+<table>
+  <tr>
+    <th> Variables </th>
+    <th> Description </th>
+    <th> Specify In ChaosEngine </th>
+    <th> Notes </th>
+  </tr>
+  <tr> 
+    <td> EC2_INSTANCE_ID </td>
+    <td> Instance Id of the target ec2 instance.</td>
+    <td> Mandatory </td>
+    <td>  </td>
+  </tr>
+  <tr> 
+     <td> EBS_VOL_ID </td>
+    <td> The EBS volume id attached to the given instance </td>
+    <td> Mandatory </td>
+    <td>  </td>
+  </tr>
+  <tr> 
+     <td> DEVICE_NAME </td>
+    <td> The device name which you wanted to mount</td>
+    <td> Mandatory </td>
+    <td> Defaults to '/dev/sdb'</td>
+  </tr>
+  <tr> 
+    <td> TOTAL_CHAOS_DURATION </td>
+    <td> The time duration for chaos insertion (sec) </td>
+    <td> Optional </td>
+    <td> Defaults to 60s </td>
+  </tr>
+  <tr>
+    <td> REGION </td>
+    <td> The region name of the target instance</td>
+    <td> Optional </td>
+    <td> </td>
+  </tr> 
+  <tr>
+    <td> INSTANCE_ID </td>
+    <td> A user-defined string that holds metadata/info about current run/instance of chaos. Ex: 04-05-2020-9-00. This string is appended as suffix in the chaosresult CR name.</td>
+    <td> Optional </td>
+    <td> Ensure that the overall length of the chaosresult CR is still < 64 characters </td>
+  </tr>
+
+</table>
+
+#### Sample ChaosEngine Manifest
+
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kube-aws/ebs-loss/engine.yaml yaml)
+```yaml
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  annotationCheck: 'false'
+  engineState: 'active'
+  chaosServiceAccount: ebs-loss-sa
+  monitoring: false
+  # It can be retain/delete
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: ebs-loss
+      spec:
+        components:
+          env: 
+            # set chaos duration (in sec) as desired
+            - name: TOTAL_CHAOS_DURATION
+              value: '60'
+
+            # Instance ID of the target ec2 instance 
+            - name: EC2_INSTANCE_ID
+              value: ''
+
+            # provide EBS volume id attached to the given instance
+            - name: EBS_VOL_ID
+              value: ''              
+
+            # Enter the device name which you wanted to mount only for AWS.   
+            - name: DEVICE_NAME
+              value: '/dev/sdb'
+              
+            # provide the region name of the instace
+            - name: REGION
+              value: ''
+```
+
+### Create the ChaosEngine Resource
+
+- Create the ChaosEngine manifest prepared in the previous step to trigger the Chaos.
+
+  `kubectl apply -f chaosengine.yml`
+
+- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/) 
+  section to identify the root cause and fix the issues.
+
+### Watch Chaos progress
+
+- View the status of the pods as they are subjected to ebs loss. 
+
+  `watch -n 1 kubectl get pods -n <application-namespace>`
+  
+- Monitor the attachment status for ebs volume from AWS CLI.
+
+  `aws ec2 describe-volumes --volume-ids <vol-id>`
+
+-  You can also use aws console to keep a watch over ebs attachment status.   
+
+### Check Chaos Experiment Result
+
+- Check whether the application is resilient to the ebs loss, once the experiment (job) is completed. The ChaosResult resource name is derived like this: `<ChaosEngine-Name>-<ChaosExperiment-Name>`.
+
+  `kubectl describe chaosresult nginx-chaos-ebs-loss -n <application-namespace>`
+
+### EBS Loss Experiment Demo
+
+- A sample recording of this experiment execution will be added soon.

--- a/docs/ec2-terminate.md
+++ b/docs/ec2-terminate.md
@@ -1,0 +1,218 @@
+---
+id: ec2-terminate
+title: EC2 Terminate Experiment Details
+sidebar_label: EC2 Terminate
+---
+------
+
+## Experiment Metadata
+
+<table>
+  <tr>
+    <th> Type </th>
+    <th> Description  </th>
+    <th> Tested K8s Platform </th>
+  </tr>
+  <tr>
+    <td> Kube AWS </td>
+    <td> Termination of an EC2 instance for a certain chaos duration</td>
+    <td> EKS </td>
+  </tr>
+</table>
+
+## Prerequisites
+
+- Ensure that Kubernetes Version > 1.13
+- Ensure that the Litmus Chaos Operator is running by executing `kubectl get pods` in operator namespace (typically, `litmus`). If not, install from [here](https://docs.litmuschaos.io/docs/getstarted/#install-litmus)
+- Ensure that the `ec2-terminate` experiment resource is available in the cluster by executing `kubectl get chaosexperiments` in the desired namespace If not, install from [here](https://hub.litmuschaos.io/api/chaos/1.9.1?file=charts/kube-aws/ec2-terminate/experiment.yaml)
+- Ensure that you have sufficient AWS access to stop and start an ec2 instance. 
+- Ensure to create a Kubernetes secret having the AWS access configuration(key) in the `CHAOS_NAMESPACE`. A sample secret file looks like:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-secret
+type: Opaque
+stringData:
+  cloud_config.yml: |-
+  # Add the cloud AWS credentials respectively
+  [default]
+  aws_access_key_id = XXXXXXXXXXXXXXXXXXX
+  aws_secret_access_key = XXXXXXXXXXXXXXX
+```
+
+## Entry-Criteria
+
+-   EC2 instance is healthy before chaos injection.
+
+## Exit-Criteria
+
+-   EC2 instance is healthy post chaos injection.
+
+## Details
+
+-   Causes termination of an EC2 instance before bringing it back to running state after the specified chaos duration. 
+-   It helps to check the performance of the application/process running on the ec2 instance.
+
+## Integrations
+
+-   EC2 Terminate can be effected using the chaos library: `litmus`, which makes use of aws sdk to start/stop an EC2 instance. 
+-   The desired chaoslib can be selected by setting the above options as value for the env variable `LIB`
+
+## Steps to Execute the Chaos Experiment
+
+- This Chaos Experiment can be triggered by creating a ChaosEngine resource on the cluster. To understand the values to provide in a ChaosEngine specification, refer [Getting Started](getstarted.md/#prepare-chaosengine)
+
+- Follow the steps in the sections below to create the chaosServiceAccount, prepare the ChaosEngine & execute the experiment.
+
+### Prepare chaosServiceAccount
+
+- Use this sample RBAC manifest to create a chaosServiceAccount in the desired (app) namespace. This example consists of the minimum necessary role permissions to execute the experiment.
+
+#### Sample Rbac Manifest
+
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kube-aws/ec2-terminate/rbac.yaml yaml)
+```yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ec2-terminate-sa
+  namespace: default
+  labels:
+    name: ec2-terminate-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ec2-terminate-sa
+  labels:
+    name: ec2-terminate-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+- apiGroups: ["","litmuschaos.io","batch"]
+  resources: ["pods","jobs","secrets","events","pods/log","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ec2-terminate-sa
+  labels:
+    name: ec2-terminate-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ec2-terminate-sa
+subjects:
+- kind: ServiceAccount
+  name: ec2-terminate-sa
+  namespace: default
+```
+
+### Prepare ChaosEngine
+
+- Provide the application info in `spec.appinfo`
+- Provide the auxiliary applications info (ns & labels) in `spec.auxiliaryAppInfo`
+- Override the experiment tunables if desired in `experiments.spec.components.env`
+- To understand the values to provided in a ChaosEngine specification, refer [ChaosEngine Concepts](chaosengine-concepts.md)
+
+#### Supported Experiment Tunables
+
+<table>
+  <tr>
+    <th> Variables </th>
+    <th> Description </th>
+    <th> Specify In ChaosEngine </th>
+    <th> Notes </th>
+  </tr>
+  <tr> 
+    <td> EC2_INSTANCE_ID </td>
+    <td> Instance Id of the target ec2 instance.</td>
+    <td> Mandatory </td>
+    <td>  </td>
+  </tr>
+  <tr> 
+    <td> TOTAL_CHAOS_DURATION </td>
+    <td> The time duration for chaos insertion (sec) </td>
+    <td> Optional </td>
+    <td> Defaults to 60s </td>
+  </tr>
+  <tr>
+    <td> REGION </td>
+    <td> The region name of the target instace</td>
+    <td> Optional </td>
+    <td> </td>
+  </tr> 
+  <tr>
+    <td> INSTANCE_ID </td>
+    <td> A user-defined string that holds metadata/info about current run/instance of chaos. Ex: 04-05-2020-9-00. This string is appended as suffix in the chaosresult CR name.</td>
+    <td> Optional </td>
+    <td> Ensure that the overall length of the chaosresult CR is still < 64 characters </td>
+  </tr>
+
+</table>
+
+#### Sample ChaosEngine Manifest
+
+[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/kube-aws/ec2-terminate/engine.yaml yaml)
+```yaml
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  annotationCheck: 'false'
+  engineState: 'active'
+  chaosServiceAccount: ec2-terminate-sa
+  monitoring: false
+  # It can be retain/delete
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: ec2-terminate
+      spec:
+        components:
+          env: 
+            # set chaos duration (in sec) as desired
+            - name: TOTAL_CHAOS_DURATION
+              value: '60'
+
+            # Instance ID of the target ec2 instance 
+            - name: EC2_INSTANCE_ID
+              value: ''
+              
+            # provide the region name of the instace
+            - name: REGION
+              value: ''
+```
+
+### Create the ChaosEngine Resource
+
+- Create the ChaosEngine manifest prepared in the previous step to trigger the Chaos.
+
+  `kubectl apply -f chaosengine.yml`
+
+- If the chaos experiment is not executed, refer to the [troubleshooting](https://docs.litmuschaos.io/docs/faq-troubleshooting/) 
+  section to identify the root cause and fix the issues.
+
+### Watch Chaos progress
+  
+- Monitor the ec2 state from AWS CLI.
+
+  `aws ec2 describe-instance-status --instance-ids <instance-id>`
+
+-  You can also use aws console to keep a watch over the instance state.   
+
+### Check Chaos Experiment Result
+
+- Check whether the application is resilient to the ec2-terminate, once the experiment (job) is completed. The ChaosResult resource name is derived like this: `<ChaosEngine-Name>-<ChaosExperiment-Name>`.
+
+  `kubectl describe chaosresult nginx-chaos-ec2-terminate -n <application-namespace>`
+
+### EC2 Terminate Experiment Demo
+
+- A sample recording of this experiment execution will be added soon.

--- a/docs/pod-cpu-hog.md
+++ b/docs/pod-cpu-hog.md
@@ -231,7 +231,13 @@ spec:
 
             - name: TOTAL_CHAOS_DURATION
               value: '60' # in seconds
-            
+
+            - name: CHAOS_INJECT_COMMAND
+              value: 'md5sum /dev/zero'
+
+            - name: CHAOS_KILL_COMMAND
+              value: "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')"
+                    
 ```
 
 ### Create the ChaosEngine Resource

--- a/docs/pod-memory-hog.md
+++ b/docs/pod-memory-hog.md
@@ -224,6 +224,8 @@ spec:
             - name: TOTAL_CHAOS_DURATION
               value: '60' # in seconds
             
+            - name: CHAOS_KILL_COMMAND
+              value: "kill -9 $(ps afx | grep \"[dd] if /dev/zero\" | awk '{print $1}' | tr '\n' ' ')"            
 ```
 
 ### Create the ChaosEngine Resource

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -77,7 +77,9 @@
         "type": "subcategory",
         "label": "Kube-AWS",
         "ids": [
-          "Kubernetes-Chaostoolkit-AWS"
+          "Kubernetes-Chaostoolkit-AWS",
+          "ebs-loss",
+          "ec2-terminate"
         ]
       },
       {


### PR DESCRIPTION
Signed-off-by: Udit Gaurav <udit.gaurav@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This PR is for the addition of docs for new experiments which are: 
  - [X] EBS Loss
  - [X] EC2 Terminate

- It also contains embedmd run for pod-cpu-hog and pod-memory-hog changes.
- Addition of the experiment in sidebar.json also modified the name of chaos toolkit ec2 terminate experiment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [x] Signed the commit for [DCO](https://github.com/litmuschaos/litmus-docs/blob/master/CONTRIBUTING.md#sign-your-work) check to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
