### PR TITLE
(fix)docs: update latest info about experiment ENV vars

### DIFF
--- a/docs/container-kill.md
+++ b/docs/container-kill.md
@@ -131,8 +131,8 @@ subjects:
   </tr>
   <tr>
     <td> TARGET_CONTAINER  </td>
-    <td> The container to be killed inside the pod </td>
-    <td> Mandatory </td>
+    <td> The name of container to be killed inside the pod </td>
+    <td> Optional </td>
     <td> If the TARGET_CONTAINER is not provided it will delete the first container </td>
   </tr>
   <tr>

--- a/docs/disk-fill.md
+++ b/docs/disk-fill.md
@@ -156,8 +156,8 @@ subjects:
   <tr> 
      <td> TARGET_CONTAINER </td>
     <td> Name of container which is subjected to disk-fill </td>
-    <td> Mandatory </td>
-    <td>  </td>
+    <td> Optional </td>
+    <td> If not provided, the first container in the targeted pod will be subject to chaos </td>
   </tr>
   <tr> 
      <td> CONTAINER_PATH </td>

--- a/docs/kafka-broker-pod-failure.md
+++ b/docs/kafka-broker-pod-failure.md
@@ -54,7 +54,6 @@ sidebar_label: Broker Pod Failure
 
 ## Integrations
 
-- Pod failures can be effected using one of these chaos libraries: `litmus`, `powerfulseal`
 - The desired chaos library can be selected by setting one of the above options as value for the environment variable `LIB`
 
 ## Steps to Execute the Chaos Experiment
@@ -229,18 +228,6 @@ subjects:
     <td> Time interval b/w two successive broker failures (sec) </td>
     <td> Optional </td>
     <td> Defaults to 5s </td>
-  </tr>
-  <tr>
-    <td> KILL_COUNT </td>
-    <td> No. of application pods to be deleted </td>
-    <td> Optional  </td>
-    <td> Default to `1`, kill_count > 1 is only supported by litmus lib , not by the powerfulseal </td>
-  </tr>
-  <tr>
-    <td> LIB </td>
-    <td> The chaos lib used to inject the chaos </td>
-    <td> Optional </td>
-    <td> Defaults to `litmus`. Supported: `litmus`, `powerfulseal </td>
   </tr>
   <tr>
     <td> INSTANCE_ID </td>

--- a/docs/pod-cpu-hog.md
+++ b/docs/pod-cpu-hog.md
@@ -163,7 +163,7 @@ subjects:
     <td> CHAOS_KILL_COMMAND </td>
     <td> The command to kill the chaos process</td>
     <td> Optional </td>
-    <td> Default to <code>kill $(find /proc -name exe -lname '*/md5sum' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1</code> </td>
+    <td> Default to <code>kill $(find /proc -name exe -lname '*/md5sum' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1)</code>. Another useful one that generally works (in case the default doesn't) is <code>kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')</code>. In case neither works, please check whether the target pod's base image offers a shell. If yes, identify appropriate shell command to kill the chaos process </td>
   </tr>   
   <tr>
     <td> RAMP_TIME </td>
@@ -220,13 +220,6 @@ spec:
 
             - name: TOTAL_CHAOS_DURATION
               value: '60' # in seconds
-
-            - name: CHAOS_INJECT_COMMAND
-              value: 'md5sum /dev/zero'
-
-            - name: CHAOS_KILL_COMMAND
-              value: "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')"
-                    
 ```
 
 ### Create the ChaosEngine Resource

--- a/docs/pod-cpu-hog.md
+++ b/docs/pod-cpu-hog.md
@@ -118,12 +118,6 @@ subjects:
     <th> Notes </th>
   </tr>
   <tr>
-    <td> TARGET_CONTAINER </td>
-    <td> Name of the container subjected to CPU stress  </td>
-    <td> Mandatory  </td>
-    <td> </td>
-  </tr>
-  <tr>
     <td> CPU_CORES </td>
     <td> Number of the cpu cores subjected to CPU stress  </td>
     <td> Optional  </td>
@@ -219,11 +213,6 @@ spec:
       spec:
         components:
           env:
-            # Provide name of target container
-            # where chaos has to be injected
-            - name: TARGET_CONTAINER
-              value: 'nginx'
-
             #number of cpu cores to be consumed
             #verify the resources the app has been launched with
             - name: CPU_CORES

--- a/docs/pod-delete.md
+++ b/docs/pod-delete.md
@@ -37,11 +37,9 @@ sidebar_label: Pod Delete
 
 - Causes (forced/graceful) pod failure of specific/random replicas of an application resources
 - Tests deployment sanity (replica availability & uninterrupted service) and recovery workflow of the application
-- The pod delete by `Powerfulseal` is only supporting single pod failure (kill_count = 1).
 
 ## Integrations
 
-- Pod failures can be effected using one of these chaos libraries: `litmus`, `powerfulseal`
 - The desired chaos library can be selected by setting one of the above options as value for the env variable `LIB`
 
 ## Steps to Execute the Chaos Experiment
@@ -53,9 +51,8 @@ sidebar_label: Pod Delete
 ### Prepare chaosServiceAccount
 
 - Use this sample RBAC manifest to create a chaosServiceAccount in the desired (app) namespace. This example consists of the minimum necessary role permissions to execute the experiment.
-- The RBAC sample manifest is different for both LIB (litmus, powerseal). Use the respective rbac sample manifest on the basis of LIB ENV.
 
-#### Sample Rbac Manifest for litmus LIB
+#### Sample Rbac Manifest 
 
 [embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-delete/rbac.yaml yaml)
 ```yaml
@@ -101,50 +98,6 @@ subjects:
 
 ```
 
-#### Sample Rbac Manifest for powerfulseal LIB
-
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/master/charts/generic/pod-delete/powerfulseal_rbac.yaml yaml)
-```yaml
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: pod-delete-sa
-  namespace: default
-  labels:
-    name: pod-delete-sa
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: pod-delete-sa
-  labels:
-    name: pod-delete-sa
-rules:
-- apiGroups: ["","litmuschaos.io","batch","apps"]
-  resources: ["pods","deployments","pods/log","events","jobs","configmaps","chaosengines","chaosexperiments","chaosresults"]
-  verbs: ["create","list","get","patch","update","delete"]
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get","list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: pod-delete-sa
-  labels:
-    name: pod-delete-sa
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: pod-delete-sa
-subjects:
-- kind: ServiceAccount
-  name: pod-delete-sa
-  namespace: default
-
-```
-
 ***Note:*** In case of restricted systems/setup, create a PodSecurityPolicy(psp) with the required permissions. The `chaosServiceAccount` can subscribe to work around the respective limitations. An example of a standard psp that can be used for litmus chaos experiments can be found [here](https://docs.litmuschaos.io/docs/next/litmus-psp/).
 
 ### Prepare ChaosEngine
@@ -173,12 +126,6 @@ subjects:
     <td> Time interval b/w two successive pod failures (in sec) </td>
     <td> Optional </td>
     <td> Defaults to 5s </td>
-  </tr>
-  <tr>
-    <td> LIB </td>
-    <td> The chaos lib used to inject the chaos </td>
-    <td> Optional  </td>
-    <td> Defaults to `litmus`. Supported: `litmus`, `powerfulseal`. In case of powerfulseal use the <a href="https://github.com/litmuschaos/chaos-charts/blob/master/charts/generic/pod-delete/powerfulseal_experiment.yaml">powerfulseal </a>experiment CR. </td>
   </tr>
   <tr>
     <td> FORCE  </td>

--- a/docs/pod-memory-hog.md
+++ b/docs/pod-memory-hog.md
@@ -118,12 +118,6 @@ subjects:
     <th> Notes </th>
   </tr>
   <tr>
-    <td> TARGET_CONTAINER </td>
-    <td> Name of the container subjected to Memory stress  </td>
-    <td> Mandatory  </td>
-    <td> </td>
-  </tr>
-  <tr>
     <td> MEMORY_CONSUMPTION </td>
     <td>  The amount of memory used of hogging a Kubernetes pod (megabytes)</td>
     <td> Optional  </td>
@@ -212,11 +206,6 @@ spec:
       spec:
         components:
           env:
-            # Provide name of target container
-            # where chaos has to be injected
-            - name: TARGET_CONTAINER
-              value: 'nginx'
-
             # Enter the amount of memory in megabytes to be consumed by the application pod
             - name: MEMORY_CONSUMPTION
               value: '500'

--- a/docs/pod-memory-hog.md
+++ b/docs/pod-memory-hog.md
@@ -150,7 +150,7 @@ subjects:
     <td> CHAOS_KILL_COMMAND </td>
     <td> The command to kill the chaos process</td>
     <td> Optional </td>
-    <td> Default to <code>kill $(find /proc -name exe -lname '*/dd' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1</code> </td>
+    <td> Defaults to <code>kill $(find /proc -name exe -lname '*/dd' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1)</code>. Another useful one that generally works (in case the default doesn't) is <code>kill -9 $(ps afx | grep \"[dd] if /dev/zero\" | awk '{print $1}' | tr '\n' ' ')</code>. In case neither works, please check whether the target pod's base image offers a shell. If yes, identify appropriate shell command to kill the chaos process</td>
   </tr>            
   <tr>
     <td> PODS_AFFECTED_PERC </td>
@@ -213,8 +213,6 @@ spec:
             - name: TOTAL_CHAOS_DURATION
               value: '60' # in seconds
             
-            - name: CHAOS_KILL_COMMAND
-              value: "kill -9 $(ps afx | grep \"[dd] if /dev/zero\" | awk '{print $1}' | tr '\n' ' ')"            
 ```
 
 ### Create the ChaosEngine Resource

--- a/docs/pod-network-corruption.md
+++ b/docs/pod-network-corruption.md
@@ -121,8 +121,8 @@ subjects:
   <tr>
     <td> TARGET_CONTAINER  </td>
     <td> Name of container which is subjected to network corruption </td>
-    <td> Mandatory </td>
-    <td> </td>
+    <td> Optional </td>
+    <td> Applicable for containerd & CRI-O runtime only. Even with these runtimes, if the value is not provided, it injects chaos on the first container of the pod </td>
   </tr>
   <tr>
     <td> NETWORK_PACKET_CORRUPTION_PERCENTAGE  </td>

--- a/docs/pod-network-duplication.md
+++ b/docs/pod-network-duplication.md
@@ -120,7 +120,7 @@ subjects:
     <td> TARGET_CONTAINER  </td>
     <td> Name of container which is subjected to network latency </td>
     <td> Optional </td>
-     <td> By default it will take the first container of the target application pod </td>
+    <td> Applicable for containerd & CRI-O runtime only. Even with these runtimes, if the value is not provided, it injects chaos on the first container of the pod </td>
   </tr>
   <tr>
     <td> NETWORK_PACKET_DUPLICATION_PERCENTAGE </td>

--- a/docs/pod-network-latency.md
+++ b/docs/pod-network-latency.md
@@ -121,8 +121,8 @@ subjects:
   <tr>
     <td> TARGET_CONTAINER  </td>
     <td> Name of container which is subjected to network latency </td>
-    <td> Mandatory </td>
-    <td> </td>
+    <td> Optional </td>
+    <td> Applicable for containerd & CRI-O runtime only. Even with these runtimes, if the value is not provided, it injects chaos on the first container of the pod </td>
   </tr>
   <tr>
     <td> NETWORK_LATENCY </td>

--- a/docs/pod-network-loss.md
+++ b/docs/pod-network-loss.md
@@ -119,8 +119,8 @@ subjects:
   <tr>
     <td> TARGET_CONTAINER  </td>
     <td> Name of container which is subjected to network loss </td>
-    <td> Mandatory </td>
-     <td> </td>
+    <td> Optional </td>
+    <td> Applicable for containerd & CRI-O runtime only. Even with these runtimes, if the value is not provided, it injects chaos on the first container of the pod</td>
   </tr>
   <tr>
     <td> NETWORK_PACKET_LOSS_PERCENTAGE </td>

--- a/website/versioned_docs/version-1.11.0/container-kill.md
+++ b/website/versioned_docs/version-1.11.0/container-kill.md
@@ -132,8 +132,8 @@ subjects:
   </tr>
   <tr>
     <td> TARGET_CONTAINER  </td>
-    <td> The container to be killed inside the pod </td>
-    <td> Mandatory </td>
+    <td> The name of container to be killed inside the pod </td>
+    <td> Optional </td>
     <td> If the TARGET_CONTAINER is not provided it will delete the first container </td>
   </tr>
   <tr>

--- a/website/versioned_docs/version-1.11.0/disk-fill.md
+++ b/website/versioned_docs/version-1.11.0/disk-fill.md
@@ -157,8 +157,8 @@ subjects:
   <tr> 
      <td> TARGET_CONTAINER </td>
     <td> Name of container which is subjected to disk-fill </td>
-    <td> Mandatory </td>
-    <td>  </td>
+    <td> Optional </td>
+    <td> If not provided, the first container in the targeted pod will be subject to chaos </td>
   </tr>
   <tr> 
      <td> CONTAINER_PATH </td>

--- a/website/versioned_docs/version-1.11.0/kafka-broker-pod-failure.md
+++ b/website/versioned_docs/version-1.11.0/kafka-broker-pod-failure.md
@@ -55,7 +55,6 @@ original_id: kafka-broker-pod-failure
 
 ## Integrations
 
-- Pod failures can be effected using one of these chaos libraries: `litmus`, `powerfulseal`
 - The desired chaos library can be selected by setting one of the above options as value for the environment variable `LIB`
 
 ## Steps to Execute the Chaos Experiment
@@ -230,18 +229,6 @@ subjects:
     <td> Time interval b/w two successive broker failures (sec) </td>
     <td> Optional </td>
     <td> Defaults to 5s </td>
-  </tr>
-  <tr>
-    <td> KILL_COUNT </td>
-    <td> No. of application pods to be deleted </td>
-    <td> Optional  </td>
-    <td> Default to `1`, kill_count > 1 is only supported by litmus lib , not by the powerfulseal </td>
-  </tr>
-  <tr>
-    <td> LIB </td>
-    <td> The chaos lib used to inject the chaos </td>
-    <td> Optional </td>
-    <td> Defaults to `litmus`. Supported: `litmus`, `powerfulseal </td>
   </tr>
   <tr>
     <td> INSTANCE_ID </td>

--- a/website/versioned_docs/version-1.11.0/pod-cpu-hog.md
+++ b/website/versioned_docs/version-1.11.0/pod-cpu-hog.md
@@ -164,7 +164,7 @@ subjects:
     <td> CHAOS_KILL_COMMAND </td>
     <td> The command to kill the chaos process</td>
     <td> Optional </td>
-    <td> Default to <code>kill $(find /proc -name exe -lname '*/md5sum' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1</code> </td>
+    <td> Default to <code>kill $(find /proc -name exe -lname '*/md5sum' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1)</code>. Another useful one that generally works (in case the default doesn't) is <code>kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')</code>. In case neither works, please check whether the target pod's base image offers a shell. If yes, identify appropriate shell command to kill the chaos process </td>
   </tr>   
   <tr>
     <td> RAMP_TIME </td>
@@ -221,13 +221,6 @@ spec:
 
             - name: TOTAL_CHAOS_DURATION
               value: '60' # in seconds
-
-            - name: CHAOS_INJECT_COMMAND
-              value: 'md5sum /dev/zero'
-
-            - name: CHAOS_KILL_COMMAND
-              value: "kill -9 $(ps afx | grep \"[md5sum] /dev/zero\" | awk '{print$1}' | tr '\n' ' ')"
-                    
 ```
 
 ### Create the ChaosEngine Resource

--- a/website/versioned_docs/version-1.11.0/pod-cpu-hog.md
+++ b/website/versioned_docs/version-1.11.0/pod-cpu-hog.md
@@ -119,12 +119,6 @@ subjects:
     <th> Notes </th>
   </tr>
   <tr>
-    <td> TARGET_CONTAINER </td>
-    <td> Name of the container subjected to CPU stress  </td>
-    <td> Mandatory  </td>
-    <td> </td>
-  </tr>
-  <tr>
     <td> CPU_CORES </td>
     <td> Number of the cpu cores subjected to CPU stress  </td>
     <td> Optional  </td>
@@ -220,11 +214,6 @@ spec:
       spec:
         components:
           env:
-            # Provide name of target container
-            # where chaos has to be injected
-            - name: TARGET_CONTAINER
-              value: 'nginx'
-
             #number of cpu cores to be consumed
             #verify the resources the app has been launched with
             - name: CPU_CORES

--- a/website/versioned_docs/version-1.11.0/pod-delete.md
+++ b/website/versioned_docs/version-1.11.0/pod-delete.md
@@ -38,11 +38,9 @@ original_id: pod-delete
 
 - Causes (forced/graceful) pod failure of specific/random replicas of an application resources
 - Tests deployment sanity (replica availability & uninterrupted service) and recovery workflow of the application
-- The pod delete by `Powerfulseal` is only supporting single pod failure (kill_count = 1).
 
 ## Integrations
 
-- Pod failures can be effected using one of these chaos libraries: `litmus`, `powerfulseal`
 - The desired chaos library can be selected by setting one of the above options as value for the env variable `LIB`
 
 ## Steps to Execute the Chaos Experiment
@@ -54,9 +52,8 @@ original_id: pod-delete
 ### Prepare chaosServiceAccount
 
 - Use this sample RBAC manifest to create a chaosServiceAccount in the desired (app) namespace. This example consists of the minimum necessary role permissions to execute the experiment.
-- The RBAC sample manifest is different for both LIB (litmus, powerseal). Use the respective rbac sample manifest on the basis of LIB ENV.
 
-#### Sample Rbac Manifest for litmus LIB
+#### Sample Rbac Manifest
 
 [embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/v1.11.x/charts/generic/pod-delete/rbac.yaml yaml)
 ```yaml
@@ -102,49 +99,6 @@ subjects:
 
 ```
 
-#### Sample Rbac Manifest for powerfulseal LIB
-
-[embedmd]:# (https://raw.githubusercontent.com/litmuschaos/chaos-charts/v1.11.x/charts/generic/pod-delete/powerfulseal_rbac.yaml yaml)
-```yaml
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: pod-delete-sa
-  namespace: default
-  labels:
-    name: pod-delete-sa
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: pod-delete-sa
-  labels:
-    name: pod-delete-sa
-rules:
-- apiGroups: ["","litmuschaos.io","batch","apps"]
-  resources: ["pods","deployments","pods/log","events","jobs","configmaps","chaosengines","chaosexperiments","chaosresults"]
-  verbs: ["create","list","get","patch","update","delete"]
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get","list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: pod-delete-sa
-  labels:
-    name: pod-delete-sa
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: pod-delete-sa
-subjects:
-- kind: ServiceAccount
-  name: pod-delete-sa
-  namespace: default
-
-```
 
 ***Note:*** In case of restricted systems/setup, create a PodSecurityPolicy(psp) with the required permissions. The `chaosServiceAccount` can subscribe to work around the respective limitations. An example of a standard psp that can be used for litmus chaos experiments can be found [here](https://docs.litmuschaos.io/docs/next/litmus-psp/).
 
@@ -174,12 +128,6 @@ subjects:
     <td> Time interval b/w two successive pod failures (in sec) </td>
     <td> Optional </td>
     <td> Defaults to 5s </td>
-  </tr>
-  <tr>
-    <td> LIB </td>
-    <td> The chaos lib used to inject the chaos </td>
-    <td> Optional  </td>
-    <td> Defaults to `litmus`. Supported: `litmus`, `powerfulseal`. In case of powerfulseal use the <a href="https://github.com/litmuschaos/chaos-charts/blob/master/charts/generic/pod-delete/powerfulseal_experiment.yaml">powerfulseal </a>experiment CR. </td>
   </tr>
   <tr>
     <td> FORCE  </td>

--- a/website/versioned_docs/version-1.11.0/pod-memory-hog.md
+++ b/website/versioned_docs/version-1.11.0/pod-memory-hog.md
@@ -119,12 +119,6 @@ subjects:
     <th> Notes </th>
   </tr>
   <tr>
-    <td> TARGET_CONTAINER </td>
-    <td> Name of the container subjected to Memory stress  </td>
-    <td> Mandatory  </td>
-    <td> </td>
-  </tr>
-  <tr>
     <td> MEMORY_CONSUMPTION </td>
     <td>  The amount of memory used of hogging a Kubernetes pod (megabytes)</td>
     <td> Optional  </td>
@@ -213,11 +207,6 @@ spec:
       spec:
         components:
           env:
-            # Provide name of target container
-            # where chaos has to be injected
-            - name: TARGET_CONTAINER
-              value: 'nginx'
-
             # Enter the amount of memory in megabytes to be consumed by the application pod
             - name: MEMORY_CONSUMPTION
               value: '500'

--- a/website/versioned_docs/version-1.11.0/pod-memory-hog.md
+++ b/website/versioned_docs/version-1.11.0/pod-memory-hog.md
@@ -151,7 +151,7 @@ subjects:
     <td> CHAOS_KILL_COMMAND </td>
     <td> The command to kill the chaos process</td>
     <td> Optional </td>
-    <td> Default to <code>kill $(find /proc -name exe -lname '*/dd' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1</code> </td>
+    <td> Defaults to <code>kill $(find /proc -name exe -lname '*/dd' 2>&1 | grep -v 'Permission denied' | awk -F/ '{print $(NF-1)}' |  head -n 1)</code>. Another useful one that generally works (in case the default doesn't) is <code>kill -9 $(ps afx | grep \"[dd] if /dev/zero\" | awk '{print $1}' | tr '\n' ' ')</code>. In case neither works, please check whether the target pod's base image offers a shell. If yes, identify appropriate shell command to kill the chaos process</td> 
   </tr>            
   <tr>
     <td> PODS_AFFECTED_PERC </td>
@@ -214,8 +214,6 @@ spec:
             - name: TOTAL_CHAOS_DURATION
               value: '60' # in seconds
             
-            - name: CHAOS_KILL_COMMAND
-              value: "kill -9 $(ps afx | grep \"[dd] if /dev/zero\" | awk '{print $1}' | tr '\n' ' ')"            
 ```
 
 ### Create the ChaosEngine Resource

--- a/website/versioned_docs/version-1.11.0/pod-network-corruption.md
+++ b/website/versioned_docs/version-1.11.0/pod-network-corruption.md
@@ -122,8 +122,8 @@ subjects:
   <tr>
     <td> TARGET_CONTAINER  </td>
     <td> Name of container which is subjected to network corruption </td>
-    <td> Mandatory </td>
-    <td> </td>
+    <td> Optional </td>
+    <td> Applicable for containerd & CRI-O runtime only. Even with these runtimes, if the value is not provided, it injects chaos on the first container of the pod </td>
   </tr>
   <tr>
     <td> NETWORK_PACKET_CORRUPTION_PERCENTAGE  </td>

--- a/website/versioned_docs/version-1.11.0/pod-network-duplication.md
+++ b/website/versioned_docs/version-1.11.0/pod-network-duplication.md
@@ -121,7 +121,7 @@ subjects:
     <td> TARGET_CONTAINER  </td>
     <td> Name of container which is subjected to network latency </td>
     <td> Optional </td>
-     <td> By default it will take the first container of the target application pod </td>
+     <td> Applicable for containerd & CRI-O runtime only. Even with these runtimes, if the value is not provided, it injects chaos on the first container of the pod </td>
   </tr>
   <tr>
     <td> NETWORK_PACKET_DUPLICATION_PERCENTAGE </td>

--- a/website/versioned_docs/version-1.11.0/pod-network-latency.md
+++ b/website/versioned_docs/version-1.11.0/pod-network-latency.md
@@ -122,8 +122,8 @@ subjects:
   <tr>
     <td> TARGET_CONTAINER  </td>
     <td> Name of container which is subjected to network latency </td>
-    <td> Mandatory </td>
-    <td> </td>
+    <td> Optional </td>
+    <td> Applicable for containerd & CRI-O runtime only. Even with these runtimes, if the value is not provided, it injects chaos on the first container of the pod </td>
   </tr>
   <tr>
     <td> NETWORK_LATENCY </td>

--- a/website/versioned_docs/version-1.11.0/pod-network-loss.md
+++ b/website/versioned_docs/version-1.11.0/pod-network-loss.md
@@ -120,8 +120,8 @@ subjects:
   <tr>
     <td> TARGET_CONTAINER  </td>
     <td> Name of container which is subjected to network loss </td>
-    <td> Mandatory </td>
-     <td> </td>
+    <td> Optional </td>
+    <td> Applicable for containerd & CRI-O runtime only. Even with these runtimes, if the value is not provided, it injects chaos on the first container of the pod </td>
   </tr>
   <tr>
     <td> NETWORK_PACKET_LOSS_PERCENTAGE </td>


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Fixes ambiguity in information about TARGET_CONTAINER env var in the experiment docs
- Improves the CHAOS_KILL_COMMAND env var explanation
- Removes references to powerfulseal lib for pod-delete based experiments as it is being deprecated within litmus

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [ ] Signed the commit for [DCO](https://github.com/litmuschaos/litmus-docs/blob/master/CONTRIBUTING.md#sign-your-work) check to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
