### PR TITLE
Add EC2 experiment updates and add target container env at missding experiment details

### DIFF
--- a/docs/ec2-terminate.md
+++ b/docs/ec2-terminate.md
@@ -20,6 +20,11 @@ sidebar_label: EC2 Terminate
   </tr>
 </table>
 
+### WARNING
+```
+If the target EC2 instance is a part of a self-managed nodegroup:
+Make sure to drain the target node if any application is running on it and also ensure to cordon the target node before running the experiment so that the experiment pods do not schedule on it. 
+```
 ## Prerequisites
 
 - Ensure that Kubernetes Version > 1.13
@@ -58,6 +63,7 @@ ENV value on `experiment.yaml`with the same name.
 
 -   Causes termination of an EC2 instance before bringing it back to running state after the specified chaos duration. 
 -   It helps to check the performance of the application/process running on the ec2 instance.
+-   When the `MANAGED_NODEGROUP` is enable then the experiment will not try to start the instance post chaos instead it will check of the addition of the new node instance to the cluster.
 
 ## Integrations
 
@@ -154,6 +160,12 @@ subjects:
     <td> Optional </td>
     <td> Defaults to 60s </td>
   </tr>
+  <tr> 
+    <td> MANAGED_NODEGROUP </td>
+    <td> Set to <code>enable</code> if the target instance is the part of self-managed nodegroups </td>
+    <td> Optional </td>
+    <td> Defaults to <code>disable</code> </td>
+  </tr>  
   <tr>
     <td> REGION </td>
     <td> The region name of the target instace</td>

--- a/docs/pod-cpu-hog.md
+++ b/docs/pod-cpu-hog.md
@@ -166,6 +166,12 @@ subjects:
     <td> If not provided, it will select target pods randomly based on provided appLabels</td>
   </tr>  
   <tr>
+    <td> TARGET_CONTAINER </td>
+    <td> Name of the target container under chaos.</td>
+    <td> Optional </td>
+    <td> If not provided, it will select the first container of the target pod</td>
+  </tr>    
+  <tr>
     <td> PODS_AFFECTED_PERC </td>
     <td> The Percentage of total pods to target  </td>
     <td> Optional </td>

--- a/docs/pod-memory-hog.md
+++ b/docs/pod-memory-hog.md
@@ -165,6 +165,12 @@ subjects:
     <td> If not provided, it will select target pods randomly based on provided appLabels</td>
   </tr>
   <tr>
+    <td> TARGET_CONTAINER </td>
+    <td> Name of the target container under chaos.</td>
+    <td> Optional </td>
+    <td> If not provided, it will select the first container of the target pod</td>
+  </tr>   
+  <tr>
     <td> CHAOS_KILL_COMMAND </td>
     <td> The command to kill the chaos process</td>
     <td> Optional </td>


### PR DESCRIPTION
Signed-off-by: udit <udit@chaosnative.com>

**What this PR does / why we need it**:

- Add EC2 experiment details like an addition on `MANAGED_NODEGROPUP` env in the experiment.
- Update `TARGET_CONTAINER` env in for pod cpu and ,memory chaos.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [X] Signed the commit for [DCO](https://github.com/litmuschaos/litmus-docs/blob/master/CONTRIBUTING.md#sign-your-work) check to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
