### PR TITLE
docs(concepts): updating the concepts table for the chaosengine, chaosresult and chaosexperiment

### DIFF
--- a/docs/admin-mode.md
+++ b/docs/admin-mode.md
@@ -117,7 +117,6 @@ spec:
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
   chaosServiceAccount: litmus-admin
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/docs/chaosengine-concepts.md
+++ b/docs/chaosengine-concepts.md
@@ -215,11 +215,11 @@ This section describes the fields in the ChaosEngine spec and the possible value
 <table>
 <tr>
   <th>Field</th>
-  <td><code>.spec.monitoring</code></td>
+  <td><code>.spec.terminationGracePeriodSeconds</code></td>
 </tr>
 <tr>
   <th>Description</th>
-  <td>Flag to enable collection of simple chaos metrics</td>
+  <td>Flag to control terminationGracePeriodSeconds for the chaos pods(abort case)</td>
 </tr>
 <tr>
   <th>Type</th>
@@ -227,17 +227,18 @@ This section describes the fields in the ChaosEngine spec and the possible value
 </tr>
 <tr>
   <th>Range</th>
-  <td><code>true</code>, <code>false</code></td>
+  <td>integer value</td>
 </tr>
 <tr>
   <th>Default</th>
-  <td><code>false</code></td>
+  <td><code>30</code></td>
 </tr>
 <tr>
   <th>Notes</th>
-  <td><code>monitoring</code> in the spec enables or disables collection of chaos metrics with an exporter pod. Metrics include count of experiments in a chaosengine & individual experiment status. It is recommended to keep this disabled.</td>
+  <td>The <code>terminationGracePeriodSeconds</code> in the spec controls the terminationGracePeriodSeconds for the chaos resources in abort case. Chaos pods contains chaos revert upon abortion steps, which continuously looking for the termination signals. The terminationGracePeriodSeconds should be provided in such a way that the chaos pods got enough time for the revert before completely terminated.</td>
 </tr>
 </table>
+
 
 <table>
 <tr>
@@ -352,7 +353,7 @@ This section describes the fields in the ChaosEngine spec and the possible value
 <table>
 <tr>
   <th>Field</th>
-  <td><code>.spec.components.runner.runnerannotation</code></td>
+  <td><code>.spec.components.runner.runnerAnnotation</code></td>
 </tr>
 <tr>
   <th>Description</th>
@@ -372,7 +373,7 @@ This section describes the fields in the ChaosEngine spec and the possible value
 </tr>
 <tr>
   <th>Notes</th>
-  <td>The <code>.components.runner.runnerannotation</code> allows developers to specify the custom annotations for the runner pod.</td>
+  <td>The <code>.components.runner.runnerAnnotation</code> allows developers to specify the custom annotations for the runner pod.</td>
 </tr>
 </table>
 
@@ -813,7 +814,7 @@ This section describes the fields in the ChaosEngine spec and the possible value
 <table>
 <tr>
   <th>Field</th>
-  <td><code>.spec.experiments[].spec.components.experimentannotation</code></td>
+  <td><code>.spec.experiments[].spec.components.experimentAnnotation</code></td>
 </tr>
 <tr>
   <th>Description</th>
@@ -833,7 +834,7 @@ This section describes the fields in the ChaosEngine spec and the possible value
 </tr>
 <tr>
   <th>Notes</th>
-  <td>The <code>.spec.components.experimentannotation</code> allows developers to specify the custom annotations for the experiment pod.</td>
+  <td>The <code>.spec.components.experimentAnnotation</code> allows developers to specify the custom annotations for the experiment pod.</td>
 </tr>
 </table>
 

--- a/docs/chaosexperiment-concepts.md
+++ b/docs/chaosexperiment-concepts.md
@@ -292,7 +292,7 @@ This section describes the fields in the ChaosExperiment spec and the possible v
 <table>
 <tr>
   <th>Field</th>
-  <td><code>.spec.definition.configmaps</code></td>
+  <td><code>.spec.definition.configMaps</code></td>
 </tr>
 <tr>
   <th>Description</th>
@@ -312,7 +312,7 @@ This section describes the fields in the ChaosExperiment spec and the possible v
 </tr>
 <tr>
   <th>Notes</th>
-  <td> The <code>.spec.definition.configmaps</code> allows the developers to mount the ConfigMap volume into the experiment pod.</td>
+  <td> The <code>.spec.definition.configMaps</code> allows the developers to mount the ConfigMap volume into the experiment pod.</td>
 </tr>
 </table>
 
@@ -346,7 +346,7 @@ This section describes the fields in the ChaosExperiment spec and the possible v
 <table>
 <tr>
   <th>Field</th>
-  <td><code>.spec.definition.experimentannotations</code></td>
+  <td><code>.spec.definition.experimentAnnotations</code></td>
 </tr>
 <tr>
   <th>Description</th>
@@ -366,7 +366,7 @@ This section describes the fields in the ChaosExperiment spec and the possible v
 </tr>
 <tr>
   <th>Notes</th>
-  <td> The <code>.spec.definition.experimentannotations</code> allows the developer to specify the Custom annotation for the chaos pod.</td>
+  <td> The <code>.spec.definition.experimentAnnotations</code> allows the developer to specify the Custom annotation for the chaos pod.</td>
 </tr>
 </table>
 

--- a/docs/chaosresult-concepts.md
+++ b/docs/chaosresult-concepts.md
@@ -62,7 +62,7 @@ This section describes the fields/details provided by the ChaosResult spec.
 <table>
 <tr>
   <th>Field</th>
-  <td><code>.status.experimentstatus.failstep</code></td>
+  <td><code>.status.experimentStatus.failstep</code></td>
 </tr>
 <tr>
   <th>Description</th>
@@ -78,14 +78,14 @@ This section describes the fields/details provided by the ChaosResult spec.
 </tr>
 <tr>
   <th>Notes</th>
-  <td>The <code>.status.experimentstatus.failstep</code> Show the step at which the experiment failed. It helps in faster debugging of failures in the experiment execution.</td>
+  <td>The <code>.status.experimentStatus.failstep</code> Show the step at which the experiment failed. It helps in faster debugging of failures in the experiment execution.</td>
 </tr>
 </table>
 
 <table>
 <tr>
   <th>Field</th>
-  <td><code>.status.experimentstatus.phase</code></td>
+  <td><code>.status.experimentStatus.phase</code></td>
 </tr>
 <tr>
   <th>Description</th>
@@ -101,14 +101,14 @@ This section describes the fields/details provided by the ChaosResult spec.
 </tr>
 <tr>
   <th>Notes</th>
-  <td>The <code>.status.experimentstatus.phase</code> shows the current phase in which the experiment is. It gets updated as the experiment proceeds.If the experiment is aborted then the status will be Aborted.</td>
+  <td>The <code>.status.experimentStatus.phase</code> shows the current phase in which the experiment is. It gets updated as the experiment proceeds.If the experiment is aborted then the status will be Aborted.</td>
 </tr>
 </table>
 
 <table>
 <tr>
   <th>Field</th>
-  <td><code>.status.experimentstatus.probesuccesspercentage</code></td>
+  <td><code>.status.experimentStatus.probesuccesspercentage</code></td>
 </tr>
 <tr>
   <th>Description</th>
@@ -124,14 +124,14 @@ This section describes the fields/details provided by the ChaosResult spec.
 </tr>
 <tr>
   <th>Notes</th>
-  <td>The <code>.status.experimentstatus.probesuccesspercentage</code> shows the probe success percentage which is a ratio of successful checks v/s total probes.</td>
+  <td>The <code>.status.experimentStatus.probesuccesspercentage</code> shows the probe success percentage which is a ratio of successful checks v/s total probes.</td>
 </tr>
 </table>
 
 <table>
 <tr>
   <th>Field</th>
-  <td><code>.status.experimentstatus.verdict</code></td>
+  <td><code>.status.experimentStatus.verdict</code></td>
 </tr>
 <tr>
   <th>Description</th>
@@ -147,7 +147,7 @@ This section describes the fields/details provided by the ChaosResult spec.
 </tr>
 <tr>
   <th>Notes</th>
-  <td>The <code>.status.experimentstatus.verdict</code> shows the verdict of the experiment. It is <code>Awaited</code> when the experiment is in progress and ends up with Pass or Fail according to the experiment result.</td>
+  <td>The <code>.status.experimentStatus.verdict</code> shows the verdict of the experiment. It is <code>Awaited</code> when the experiment is in progress and ends up with Pass or Fail according to the experiment result.</td>
 </tr>
 </table>
 

--- a/docs/cstor-pool-chaos.md
+++ b/docs/cstor-pool-chaos.md
@@ -148,7 +148,6 @@ spec:
   # It can be true/false
   annotationCheck: 'false'
   chaosServiceAccount: cStor-pool-chaos-sa
-  monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'
   experiments:

--- a/docs/faq-general.md
+++ b/docs/faq-general.md
@@ -280,7 +280,7 @@ To restart chaosengine, check the `.spec.engineState`, which should be equal to 
 
 Litmus provides a basic set of prometheus metrics indicating the total count of chaos experiments, passed/failed 
 experiments and individual status of experiments specified in the ChaosEngine, which can be queried against the monitor 
-pod. Work to enhance and improve this is underway. The default mode is to run experiments with `monitoring: false`.
+pod. Work to enhance and improve this is underway.
 
 ### Does Litmus track any usage metrics on the test clusters?
 

--- a/docs/namespaced-mode.md
+++ b/docs/namespaced-mode.md
@@ -75,7 +75,6 @@ spec:
   annotationCheck: 'true'
   engineState: 'active'
   chaosServiceAccount: litmus
-  monitoring: false
   jobCleanUpPolicy: 'delete'
   experiments:
     - name: pod-delete

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -32,7 +32,6 @@ spec:
       appkind: 'deployment'
     annotationCheck: 'true'
     chaosServiceAccount: pod-delete-sa
-    monitoring: false
     jobCleanUpPolicy: 'delete'
     experiments:
       - name: pod-delete
@@ -71,7 +70,6 @@ spec:
       appkind: 'deployment'
     annotationCheck: 'true'
     chaosServiceAccount: pod-delete-sa
-    monitoring: false
     jobCleanUpPolicy: 'delete'
     experiments:
       - name: pod-delete
@@ -120,7 +118,6 @@ spec:
       appkind: 'deployment'
     annotationCheck: 'true'
     chaosServiceAccount: pod-delete-sa
-    monitoring: false
     jobCleanUpPolicy: 'delete'
     experiments:
       - name: pod-delete
@@ -166,7 +163,6 @@ spec:
       appkind: 'deployment'
     annotationCheck: 'true'
     chaosServiceAccount: pod-delete-sa
-    monitoring: false
     jobCleanUpPolicy: 'delete'
     experiments:
       - name: pod-delete
@@ -211,7 +207,6 @@ spec:
       appkind: 'deployment'
     annotationCheck: 'true'
     chaosServiceAccount: pod-delete-sa
-    monitoring: false
     jobCleanUpPolicy: 'delete'
     experiments:
       - name: pod-delete
@@ -257,7 +252,6 @@ spec:
     annotationCheck: 'true'
     auxiliaryAppInfo: ''
     chaosServiceAccount: pod-delete-sa
-    monitoring: false
     jobCleanUpPolicy: 'delete'
     experiments:
       - name: pod-delete
@@ -305,7 +299,6 @@ spec:
     #ex. values: ns1:name=percona,ns2:run=nginx
     auxiliaryAppInfo: ''
     chaosServiceAccount: pod-delete-sa
-    monitoring: false
     # It can be delete/retain
     jobCleanUpPolicy: 'delete'
     experiments:
@@ -351,7 +344,6 @@ spec:
     annotationCheck: 'true'
     auxiliaryAppInfo: ''
     chaosServiceAccount: pod-delete-sa
-    monitoring: false
     jobCleanUpPolicy: 'delete'
     experiments:
       - name: pod-delete
@@ -402,7 +394,6 @@ spec:
       appkind: 'deployment'
     annotationCheck: 'true'
     chaosServiceAccount: pod-delete-sa
-    monitoring: false
     jobCleanUpPolicy: 'delete'
     experiments:
       - name: pod-delete


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham@chaosnative.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Removed monitoring field
-  Adding terminationGracePeriodSeconds
- converting experimentannotations, configmaps, runnerannotations and experimentstatus to camel case

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Checklist:**
-   [ ] Fixes #<issue number>
-   [x] Signed the commit for [DCO](https://github.com/litmuschaos/litmus-docs/blob/master/CONTRIBUTING.md#sign-your-work) check to be passed
-   [x] Labelled this PR & related issue with `documentation` tag
