### PR TITLE
Fix Incorrect Reference to ChaosEngine Property `.spec.jobCleanUpPolicy`

### DIFF
--- a/docs/chaosengine-concepts.md
+++ b/docs/chaosengine-concepts.md
@@ -243,7 +243,7 @@ This section describes the fields in the ChaosEngine spec and the possible value
 <table>
 <tr>
   <th>Field</th>
-  <td><code>.spec.jobCleanupPolicy</code></td>
+  <td><code>.spec.jobCleanUpPolicy</code></td>
 </tr>
 <tr>
   <th>Description</th>
@@ -263,7 +263,7 @@ This section describes the fields in the ChaosEngine spec and the possible value
 </tr>
 <tr>
   <th>Notes</th>
-  <td><The <code>jobCleanupPolicy</code> controls whether or not the experiment pods are removed once execution completes. Set to <code>retain</code> for debug purposes (in the absence of standard logging mechanisms).</td>
+  <td><The <code>jobCleanUpPolicy</code> controls whether or not the experiment pods are removed once execution completes. Set to <code>retain</code> for debug purposes (in the absence of standard logging mechanisms).</td>
 </tr>
 </table>
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Fixes incorrect reference to ChaosEngine property `.spec.jobCleanUpPolicy`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #497

**Special notes for your reviewer**:

**Checklist:**
-   [x] Fixes #497 
-   [x] Signed the commit for [DCO](https://github.com/litmuschaos/litmus-docs/blob/master/CONTRIBUTING.md#sign-your-work) check to be passed
-   [ ] Labelled this PR & related issue with `documentation` tag
