### PR TITLE
Bumped spellcheck GitHub action to version 0.20.0

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
     # The checkout step
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.11.0
+    - uses: rojopolis/spellcheck-github-actions@0.20.0
       name: Spellcheck
       with:
         source_files: 'docs/*.md'


### PR DESCRIPTION
I have recently released 0.20.0 of the spellcheck GitHub action, I can see that you are using 0.11.0, so an update could be useful to you. Let me know if you have any issues with the proposal and I will try to accommodate.

I can recommend [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, if you want a PR proposing a basic configuration, please let me know.
